### PR TITLE
Place top nav over everything else

### DIFF
--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -22,6 +22,7 @@ img {
   .home header nav.top-bar {
     background: #fff;
     height: 51px;
+    z-index: 9999;
   }
 
   .home header nav.top-bar .toggle-topbar a {


### PR DESCRIPTION
The responsive layout on the home page uses `z-index` to correctly layer
the images. This causes some of the drop down items in the top nav to
render behind these images, making them inaccessible on the home page.
Giving the top nav a higher `z-index` fixes this.

Closes #22
