### PR TITLE
Add descriptions for proposal fields

### DIFF
--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -235,6 +235,12 @@ div.content {
   padding-top: 0;
 }
 
+form small {
+  color: #999;
+  display: block;
+  margin: -.9rem 0 1rem;
+}
+
 footer {
   background: url(/static/img/bg-footer.png) top center no-repeat;
   color: #fff;

--- a/pygotham/talks/forms.py
+++ b/pygotham/talks/forms.py
@@ -21,14 +21,44 @@ class TalkSubmissionForm(ModelForm):
         exclude = ('status',)
         field_args = {
             'name': {'label': 'Title'},
-            'description': {'label': 'Please include a brief summary of the talk as it should appear on the site'},
+            'description': {
+                'label': 'Description',
+                'description': (
+                    'If your talk is accepted this will be made public and '
+                    'printed in the program. Should be one paragraph.'
+                ),
+            },
             'level': {'label': 'Experience Level'},
             'type': {'label': 'Type'},
             'duration': {'label': 'Duration'},
-            'abstract': {'label': 'Please give a more detailed description of the talk'},
-            'objectives': {'label': 'Objectives'},
-            'target_audience': {'label': 'Target Audience'},
-            'outline': {'label': 'This outline should cover the sections and key points of the talk (think table of contents'},
+            'abstract': {
+                'label': 'Abstract',
+                'description': (
+                    'Detailed description. Will be made public if your talk '
+                    'is accepted.'
+                ),
+            },
+            'objectives': {
+                'label': 'Objectives',
+                'description': (
+                    'What do you hope to accomplish with this talk?'
+                ),
+            },
+            'target_audience': {
+                'label': 'Target Audience',
+                'description': (
+                    'Who is the intended audience for your talk? (Be '
+                    'specific; "Python programmers" is not a good answer to '
+                    'this question.)'
+                ),
+            },
+            'outline': {
+                'label': 'Outline',
+                'description': (
+                    'Sections and key points of the talk meant to give the '
+                    'committee an overview.'
+                ),
+            },
             'additional_requirements': {'label': 'Additional Requirements'},
             'recording_release': {
                 'label': 'Recording Release',


### PR DESCRIPTION
WTForms offers a `description` argument to give more information about
form fields. These descriptions will hopefully give users a better
understanding of the purpose of each field.

Styles are being included to give a better visual appearance to these
descriptions.

Some of this text is taken from the PyCon website.

Closes #27
