### PR TITLE
Use local time

### DIFF
--- a/pygotham/events/__init__.py
+++ b/pygotham/events/__init__.py
@@ -1,7 +1,6 @@
 """Events package."""
 
-from datetime import datetime
-
+import arrow
 from sqlalchemy import or_
 
 from pygotham.events.models import Event
@@ -11,7 +10,7 @@ __all__ = 'get_current',
 
 def get_current():
     """Get the current event."""
-    now = datetime.utcnow()
+    now = arrow.utcnow().to('America/New_York')
 
     return Event.query.filter(
         Event.active == True,

--- a/pygotham/events/models.py
+++ b/pygotham/events/models.py
@@ -1,6 +1,7 @@
 """Events models."""
 
-from datetime import datetime
+import arrow
+from sqlalchemy_utils.types.arrow import ArrowType
 
 from pygotham.core import db
 
@@ -22,20 +23,20 @@ class Event(db.Model):
 
     # Fields to control when the event is active
     active = db.Column(db.Boolean, nullable=False)
-    activity_begins = db.Column(db.DateTime)
-    activity_ends = db.Column(db.DateTime)
+    activity_begins = db.Column(ArrowType)
+    activity_ends = db.Column(ArrowType)
 
     # Proposal window
-    proposals_begin = db.Column(db.DateTime)
-    proposals_end = db.Column(db.DateTime)
+    proposals_begin = db.Column(ArrowType)
+    proposals_end = db.Column(ArrowType)
 
     # Registration informatino
     registration_closed = db.Column(
         db.Boolean, server_default='false', nullable=False,
     )
     registration_url = db.Column(db.String(255))
-    registration_begins = db.Column(db.DateTime)
-    registration_ends = db.Column(db.DateTime)
+    registration_begins = db.Column(ArrowType)
+    registration_ends = db.Column(ArrowType)
 
     def __str__(self):
         """Return a printable representation."""
@@ -51,7 +52,7 @@ class Event(db.Model):
         less than
         :attribute:`~pygotham.events.models.Event.proposals_end`.
         """
-        now = datetime.utcnow()
+        now = arrow.utcnow().to('America/New_York')
         if not self.proposals_begin or now < self.proposals_begin:
             return False
         if self.proposals_end and self.proposals_end < now:
@@ -82,7 +83,7 @@ class Event(db.Model):
         if not self.registration_url:
             return False
 
-        now = datetime.utcnow()
+        now = arrow.utcnow().to('America/New_York')
         if not self.registration_begins or now < self.registration_begins:
             return False
         if self.registration_ends and self.registration_ends < now:

--- a/pygotham/news/__init__.py
+++ b/pygotham/news/__init__.py
@@ -1,6 +1,6 @@
 """News package."""
 
-from datetime import datetime
+import arrow
 
 from pygotham.core import db
 from pygotham.news.models import Announcement
@@ -10,7 +10,7 @@ __all__ = 'get_active',
 
 def get_active():
     """Get the active announcements."""
-    now = datetime.utcnow()
+    now = arrow.utcnow().to('America/New_York')
 
     return Announcement.query.filter(
         Announcement.active == True,

--- a/pygotham/news/models.py
+++ b/pygotham/news/models.py
@@ -1,9 +1,8 @@
 """News models."""
 
-from datetime import datetime
-
 from slugify import slugify
 from sqlalchemy_utils.decorators import generates
+from sqlalchemy_utils.types.arrow import ArrowType
 
 from pygotham.core import db
 
@@ -22,7 +21,7 @@ class Announcement(db.Model):
     content = db.Column(db.Text, nullable=False)
 
     active = db.Column(db.Boolean, nullable=False)
-    published = db.Column(db.DateTime)
+    published = db.Column(ArrowType)
 
     def __str__(self):
         return self.title

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'WTForms-Components==0.9.3',
         'Werkzeug==0.9.6',
         'alembic==0.6.5',
+        'arrow==0.4.2',
         'bleach==1.4',
         'blinker==1.3',
         'cssmin==0.2.0',


### PR DESCRIPTION
When entering times through the admin, it's natural for people to do so
using their local time (in the case of everyone working on PyGotham
that's Eastern). While UTC could be entered, there are places where the
date is displayed on the site. To allow everyone to always think in
local time, Arrow is being introduced. Fortunately SQLAlchemy-Utils has
an `ArrowType` that can be used in place of `DateTimeFIeld`s.
