### PR TITLE
Create anchors to jump to specific sponsors

### DIFF
--- a/pygotham/frontend/templates/sponsors/index.html
+++ b/pygotham/frontend/templates/sponsors/index.html
@@ -16,6 +16,7 @@
           <ul class="sponsors">
             {% for sponsor in level.accepted_sponsors.order_by('name').all() %}
               <li class="columns large-4">
+                <a name="{{ sponsor.slug }}"></a>
                 <div>
                   <a href="{{ sponsor.url }}">
                     <img src="{{ sponsor.logo }}" alt="{{ sponsor.name }}">

--- a/pygotham/sponsors/models.py
+++ b/pygotham/sponsors/models.py
@@ -1,6 +1,7 @@
 """Sponsors models."""
 
 from cached_property import cached_property
+from slugify import slugify
 
 from pygotham.core import db
 
@@ -62,3 +63,7 @@ class Sponsor(db.Model):
 
     def __str__(self):
         return self.name
+
+    @cached_property
+    def slug(self):
+        return slugify(self.name)


### PR DESCRIPTION
Providing direct links to sponsors gives us the chance to use it in
announcements (e.g., on Twitter) as well as gives the sponsors a chance
to show off their sponsorship.

This is accomplished by generating a slug from each sponsor's name and
placing an anchor inside the `<li>`. Currently the slug is generated on
demand. In the future this may be handled as a database field.

Closes #36
