### PR TITLE
Use Foundation box grid for Sponsors page

### DIFF
--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -134,23 +134,17 @@ img {
   text-align: center;
 }
 
-#wrapper.sponsors ul.sponsors {
-  list-style: none;
-  overflow: hidden;
-}
-
 #wrapper.sponsors ul.sponsors li div {
   border: 1px solid #999;
   border-radius: 3px;
   height: 320px;
-  margin-bottom: 30px;
   overflow: auto;
   padding: 15px;
   text-align: center;
 }
 
 #wrapper.sponsors ul.sponsors li img {
-  width: 185px;
+  max-width: 185px;
 }
 
 #wrapper.sponsors ul.sponsors li p {

--- a/pygotham/frontend/templates/sponsors/index.html
+++ b/pygotham/frontend/templates/sponsors/index.html
@@ -13,7 +13,7 @@
         <div class="row">
           <h2>{{ level }}</h2>
 
-          <ul class="sponsors">
+          <ul class="sponsors large-block-grid-3">
             {% for sponsor in level.accepted_sponsors.order_by('name').all() %}
               <li class="columns large-4">
                 <a name="{{ sponsor.slug }}"></a>


### PR DESCRIPTION
Foundation has a box grid layout available. It accomplishes what I tried
to do with CSS in a much smarter way. It also handles resizing the grid
responsively, in this case using 4, 3, or 2 columns depending on the
viewport's size.
