### PR TITLE
Add sponsors to the home page

### DIFF
--- a/pygotham/frontend/home.py
+++ b/pygotham/frontend/home.py
@@ -4,6 +4,7 @@ from flask import Blueprint, render_template
 
 from pygotham.core import db
 from pygotham.news import get_active
+from pygotham.sponsors import get_accepted
 
 __all__ = 'blueprint',
 
@@ -19,4 +20,6 @@ blueprint = Blueprint(
 def index():
     """Return the home page."""
     announcements = get_active()
-    return render_template('home/index.html', announcements=announcements)
+    sponsors = get_accepted()
+    return render_template(
+        'home/index.html', announcements=announcements, sponsors=sponsors)

--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -126,6 +126,18 @@ img {
   }
 }
 
+#wrapper.home div.content .sponsors h2 {
+  font-size: 2.75rem;
+}
+
+#wrapper.home div.content .sponsors ul li {
+  text-align: center;
+}
+
+#wrapper.home div.content .sponsors ul li img {
+  max-width: 150px;
+}
+
 #wrapper.sponsors [class*="column"] + [class*="column"]:last-child {
   float: left;
 }
@@ -382,8 +394,10 @@ footer a {
   margin-top: 20px;
 }
 
-.announcements h3 {
-  font-size: 2.75rem;
+@media only screen and (max-width: 1024px) {
+  .announcements h3 {
+    font-size: 2.75rem;
+  }
 }
 
 .announcements ol {

--- a/pygotham/frontend/templates/home/index.html
+++ b/pygotham/frontend/templates/home/index.html
@@ -16,26 +16,39 @@
     <div class="nj"></div>
   </section>
 
-  {% if sponsors %}
-    <section class="sponsors">
-      <h2>Sponsors</h2>
-    </section>
-  {% endif %}
+  {% if sponsors or announcements %}
+    <div class="row">
+      <section class="sponsors columns large-8">
+        {% if sponsors %}
+          <h2>Sponsors</h2>
+          <ul class="large-block-grid-4 medium-block-grid-3 small-block-grid-2">
+            {% for sponsor in sponsors %}
+              <li>
+                <a href="{{ url_for('sponsors.index') }}#{{ sponsor.slug }}">
+                  <img src="{{ sponsor.logo }}" alt="{{ sponsor.name }}">
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </section>
 
-  {% if announcements %}
-    <section class="row announcements">
-      <h3>Announcements</h3>
-      <ol>
-        {% for announcement in announcements %}
-          <li>
-            <h4>{{ announcement }}</h4>
-            <time datetime="{{ announcement.published }}">
-              {{ announcement.published.strftime('%m.%d.%y') }}
-            </time>
-            <p>{{ announcement.content|rst|safe }}</p>
-          </li>
-        {% endfor %}
-      </ol>
-    </section>
+      <aside class="announcements columns offset-1 large-3">
+        {% if announcements %}
+          <h3>Announcements</h3>
+          <ol>
+            {% for announcement in announcements %}
+              <li>
+                <h4>{{ announcement }}</h4>
+                <time datetime="{{ announcement.published }}">
+                  {{ announcement.published.strftime('%m.%d.%y') }}
+                </time>
+                <p>{{ announcement.content|rst|safe }}</p>
+              </li>
+            {% endfor %}
+          </ol>
+        {% endif %}
+      </aside>
+    </div>
   {% endif %}
 {% endblock %}

--- a/pygotham/sponsors/__init__.py
+++ b/pygotham/sponsors/__init__.py
@@ -1,1 +1,11 @@
 """Sponsors package."""
+
+from pygotham.sponsors.models import Level, Sponsor
+
+__all__ = 'get_accepted',
+
+
+def get_accepted():
+    """Get the accepted sponsors."""
+    return Sponsor.query.filter(
+        Sponsor.accepted == True).join(Level).order_by(Level.order).all()


### PR DESCRIPTION
Sponsors are now being displayed on the home page. They are positioned
to the left of the announcements, which is now an aside. In the case of
small viewports, the announcements appear below the sponsors.

To accomplish this, a `get_accepted` function is being added to the
`sponsors` package. It behaves similarly to the `news.get_active`
function.
