### PR TITLE
Perform flake8-driven clean up

### DIFF
--- a/pygotham/admin/__init__.py
+++ b/pygotham/admin/__init__.py
@@ -10,7 +10,7 @@ from flask.ext.login import current_user
 
 from pygotham import factory, filters
 
-__all__ = 'create_app',
+__all__ = ('create_app',)
 
 
 class HomeView(AdminIndexView):

--- a/pygotham/admin/events.py
+++ b/pygotham/admin/events.py
@@ -5,7 +5,7 @@ import wtforms
 from pygotham.admin.utils import model_view
 from pygotham.events import models
 
-__all__ = 'EventModelView',
+__all__ = ('EventModelView',)
 
 
 EventModelView = model_view(

--- a/pygotham/admin/menulinks.py
+++ b/pygotham/admin/menulinks.py
@@ -4,7 +4,7 @@ from flask.ext.admin.base import MenuLink
 
 from pygotham.admin.utils import menu_link
 
-__all__ = 'Login', 'Logout'
+__all__ = ('Login', 'Logout')
 
 # Go back to the main site. Use '/' because the view is in a completely
 # different app.

--- a/pygotham/admin/news.py
+++ b/pygotham/admin/news.py
@@ -5,7 +5,7 @@ import wtforms
 from pygotham.admin.utils import model_view
 from pygotham.news import models
 
-__all__ = 'AnnouncementModelView',
+__all__ = ('AnnouncementModelView',)
 
 
 AnnouncementModelView = model_view(

--- a/pygotham/admin/sponsors.py
+++ b/pygotham/admin/sponsors.py
@@ -3,7 +3,7 @@
 from pygotham.admin.utils import model_view
 from pygotham.sponsors import models
 
-__all__ = 'LevelModelView', 'SponsorModelView'
+__all__ = ('LevelModelView', 'SponsorModelView')
 
 CATEGORY = 'Sponsors'
 

--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -3,7 +3,7 @@
 from pygotham.admin.utils import model_view
 from pygotham.talks import models
 
-__all__ = 'CategoryModelView', 'TalkModelView', 'TalkReviewModelView',
+__all__ = ('CategoryModelView', 'TalkModelView', 'TalkReviewModelView')
 
 
 CategoryModelView = model_view(

--- a/pygotham/admin/users.py
+++ b/pygotham/admin/users.py
@@ -3,7 +3,7 @@
 from pygotham.admin.utils import model_view
 from pygotham.users import models
 
-__all__ = 'RoleModelView', 'UserModelView'
+__all__ = ('RoleModelView', 'UserModelView')
 
 
 RoleModelView = model_view(models.Role, 'Roles', 'Users')

--- a/pygotham/admin/utils.py
+++ b/pygotham/admin/utils.py
@@ -1,10 +1,12 @@
+"""Admin application helper utilities."""
+
 from flask.ext.admin.base import MenuLink
 from flask.ext.admin.contrib.sqla import ModelView
 from flask.ext.login import current_user
 
 from pygotham.core import db
 
-__all__ = 'menu_link', 'model_view',
+__all__ = ('menu_link', 'model_view')
 
 
 class AdminModelView(ModelView):

--- a/pygotham/core.py
+++ b/pygotham/core.py
@@ -5,7 +5,7 @@ from flask.ext.migrate import Migrate
 from flask.ext.security import Security
 from flask.ext.sqlalchemy import SQLAlchemy
 
-__all__ = 'db',
+__all__ = ('db',)
 
 db = SQLAlchemy()
 mail = Mail()

--- a/pygotham/events/__init__.py
+++ b/pygotham/events/__init__.py
@@ -5,7 +5,7 @@ from sqlalchemy import or_
 
 from pygotham.events.models import Event
 
-__all__ = 'get_current',
+__all__ = ('get_current',)
 
 
 def get_current():

--- a/pygotham/events/models.py
+++ b/pygotham/events/models.py
@@ -5,7 +5,7 @@ from sqlalchemy_utils.types.arrow import ArrowType
 
 from pygotham.core import db
 
-__all__ = 'Event',
+__all__ = ('Event',)
 
 
 class Event(db.Model):
@@ -85,9 +85,11 @@ class Event(db.Model):
 
         now = arrow.utcnow().to('America/New_York').naive
         print(now)
-        if not self.registration_begins or now < self.registration_begins.naive:
+        begins = self.registration_begins
+        if not begins or now < begins.naive:
             return False
-        if self.registration_ends and self.registration_ends.naive < now:
+        ends = self.registration_ends
+        if ends and ends.naive < now:
             return False
 
         return True

--- a/pygotham/factory.py
+++ b/pygotham/factory.py
@@ -7,7 +7,7 @@ from pygotham.core import db, mail, migrate, security
 from pygotham.models import Role, User
 from pygotham.utils import check_required_settings, register_blueprints
 
-__all__ = 'create_app',
+__all__ = ('create_app',)
 
 
 def create_app(package_name, package_path, settings_override=None,
@@ -21,7 +21,6 @@ def create_app(package_name, package_path, settings_override=None,
                                          Flask-Security blueprints.
 
     """
-
     app = Flask(package_name, instance_relative_config=True)
 
     app.config.from_object('pygotham.settings')

--- a/pygotham/filters.py
+++ b/pygotham/filters.py
@@ -3,7 +3,7 @@
 import bleach
 from docutils import core
 
-__all__ = 'rst_to_html'
+__all__ = ('rst_to_html',)
 
 _ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'dl', 'dt', 'dd', 'cite',

--- a/pygotham/frontend/__init__.py
+++ b/pygotham/frontend/__init__.py
@@ -10,7 +10,7 @@ from flask.ext.foundation import Foundation
 from pygotham import factory, filters
 from pygotham.events import get_current as get_current_event
 
-__all__ = 'create_app', 'route'
+__all__ = ('create_app', 'route')
 
 
 def create_app(settings_override=None):

--- a/pygotham/frontend/about.py
+++ b/pygotham/frontend/about.py
@@ -4,7 +4,7 @@ from flask import Blueprint
 
 from pygotham.frontend import direct_to_template
 
-__all__ = 'blueprint',
+__all__ = ('blueprint',)
 
 blueprint = Blueprint('about', __name__, url_prefix='/about')
 

--- a/pygotham/frontend/home.py
+++ b/pygotham/frontend/home.py
@@ -2,11 +2,10 @@
 
 from flask import Blueprint, render_template
 
-from pygotham.core import db
 from pygotham.news import get_active
 from pygotham.sponsors import get_accepted
 
-__all__ = 'blueprint',
+__all__ = ('blueprint',)
 
 blueprint = Blueprint(
     'home',

--- a/pygotham/frontend/profile.py
+++ b/pygotham/frontend/profile.py
@@ -8,7 +8,7 @@ from pygotham.core import db
 from pygotham.frontend import route
 from pygotham.models import Talk
 
-__all__ = 'blueprint',
+__all__ = ('blueprint',)
 
 blueprint = Blueprint('profile', __name__, url_prefix='/profile')
 

--- a/pygotham/frontend/registration.py
+++ b/pygotham/frontend/registration.py
@@ -4,7 +4,7 @@ from flask import Blueprint
 
 from pygotham.frontend import direct_to_template
 
-__all__ = 'blueprint',
+__all__ = ('blueprint',)
 
 blueprint = Blueprint('registration', __name__, url_prefix='/registration')
 

--- a/pygotham/frontend/sponsors.py
+++ b/pygotham/frontend/sponsors.py
@@ -8,7 +8,7 @@ from pygotham.core import db
 from pygotham.frontend import direct_to_template, route
 from pygotham.models import Level, Sponsor
 
-__all__ = 'blueprint',
+__all__ = ('blueprint',)
 
 blueprint = Blueprint('sponsors', __name__, url_prefix='/sponsors')
 

--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -9,7 +9,7 @@ from pygotham.events import get_current
 from pygotham.frontend import direct_to_template, route
 from pygotham.models import Talk
 
-__all__ = 'blueprint'
+__all__ = ('blueprint',)
 
 blueprint = Blueprint('talks', __name__, url_prefix='/talks')
 
@@ -22,7 +22,11 @@ direct_to_template(
 
 
 @route(
-    blueprint, '/new', defaults={'pk': None}, endpoint='submit', methods=('GET', 'POST'))
+    blueprint,
+    '/new',
+    defaults={'pk': None},
+    endpoint='submit',
+    methods=('GET', 'POST'))
 @route(blueprint, '/<int:pk>/edit', endpoint='edit', methods=('GET', 'POST',))
 @login_required
 def proposal(pk=None):

--- a/pygotham/news/__init__.py
+++ b/pygotham/news/__init__.py
@@ -5,7 +5,7 @@ import arrow
 from pygotham.core import db
 from pygotham.news.models import Announcement
 
-__all__ = 'get_active',
+__all__ = ('get_active',)
 
 
 def get_active():

--- a/pygotham/news/models.py
+++ b/pygotham/news/models.py
@@ -6,7 +6,7 @@ from sqlalchemy_utils.types.arrow import ArrowType
 
 from pygotham.core import db
 
-__all__ = 'Announcement',
+__all__ = ('Announcement',)
 
 
 class Announcement(db.Model):
@@ -24,8 +24,10 @@ class Announcement(db.Model):
     published = db.Column(ArrowType)
 
     def __str__(self):
+        """Return a printable representation."""
         return self.title
 
     @generates(slug)
     def _create_slug(self):
+        """Return the slug for the announcement."""
         return slugify(self.title)

--- a/pygotham/sponsors/__init__.py
+++ b/pygotham/sponsors/__init__.py
@@ -2,7 +2,7 @@
 
 from pygotham.sponsors.models import Level, Sponsor
 
-__all__ = 'get_accepted',
+__all__ = ('get_accepted',)
 
 
 def get_accepted():

--- a/pygotham/sponsors/forms.py
+++ b/pygotham/sponsors/forms.py
@@ -7,14 +7,14 @@ from wtforms_alchemy import model_form_factory
 
 from pygotham.models import Level, Sponsor
 
-__all__ = 'SponsorApplicationForm',
+__all__ = ('SponsorApplicationForm',)
 
 ModelForm = model_form_factory(Form)
 
 
 class SponsorApplicationForm(ModelForm):
 
-    """Form for creating :class:`~pygotham.models.Sponsor`. instances"""
+    """Form for creating :class:`~pygotham.models.Sponsor` instances."""
 
     level = QuerySelectField(query_factory=Level.query.all)
 

--- a/pygotham/sponsors/models.py
+++ b/pygotham/sponsors/models.py
@@ -22,6 +22,7 @@ class Level(db.Model):
     limit = db.Column(db.Integer, default=0)
 
     def __str__(self):
+        """Return a printable representation."""
         return self.name
 
     @cached_property
@@ -62,8 +63,10 @@ class Sponsor(db.Model):
     applicant = db.relationship('User')
 
     def __str__(self):
+        """Return a printable representation."""
         return self.name
 
     @cached_property
     def slug(self):
+        """Return the slug for the sponsor."""
         return slugify(self.name)

--- a/pygotham/talks/forms.py
+++ b/pygotham/talks/forms.py
@@ -1,13 +1,12 @@
 """Talks forms."""
 
 from flask.ext.wtf import Form
-from wtforms import HiddenField
 from wtforms.validators import Optional
 from wtforms_alchemy import model_form_factory
 
 from pygotham.talks.models import Talk
 
-__all__ = 'TalkSubmissionForm',
+__all__ = ('TalkSubmissionForm',)
 
 ModelForm = model_form_factory(Form)
 

--- a/pygotham/talks/models.py
+++ b/pygotham/talks/models.py
@@ -2,7 +2,7 @@
 
 from pygotham.core import db
 
-__all__ = 'Category', 'Talk',
+__all__ = ('Category', 'Talk')
 
 
 class Category(db.Model):

--- a/pygotham/users/forms.py
+++ b/pygotham/users/forms.py
@@ -7,7 +7,7 @@ from wtforms_alchemy import Unique, model_form_factory
 
 from pygotham.models import User
 
-__all__ = 'ProfileForm',
+__all__ = ('ProfileForm',)
 
 ModelForm = model_form_factory(Form)
 

--- a/pygotham/users/models.py
+++ b/pygotham/users/models.py
@@ -4,7 +4,7 @@ from flask.ext.security import RoleMixin, UserMixin
 
 from pygotham.core import db
 
-__all__ = 'Role', 'User',
+__all__ = ('Role', 'User')
 
 roles_users = db.Table(
     'roles_users',

--- a/pygotham/utils.py
+++ b/pygotham/utils.py
@@ -5,7 +5,7 @@ import pkgutil
 
 from flask import Blueprint
 
-__all__ = 'check_required_settings', 'register_blueprints',
+__all__ = ('check_required_settings', 'register_blueprints',)
 
 DOES_NOT_EXIST = '!@DNE@!'  # Placeholder value to use for missing settings.
 REQUIRED_SETTINGS = 'SECRET_KEY', 'SECURITY_PASSWORD_SALT'


### PR DESCRIPTION
A handful of changes are being made to reduce the amount of complaining
that flake8 does. The specifics aren't too important, but the general
changes are:
- `__all__` is being standardized to only include a trailing comma when
  there is only one item, with all items being surrounded by
  parentheses. The latter change is needed for `pep257` to process the
  file.
- Lines are being shorted to fit within 79 characters.
- Docstrings are being added.
- Unused imports are being removed.
