### PR TITLE
Add filters to the talk admin

### DIFF
--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -17,7 +17,8 @@ TalkModelView = model_view(
     models.Talk,
     'Talks',
     'Talks',
-    column_list=('name', 'status', 'level', 'type', 'user'),
+    column_filters=('status', 'duration', 'level'),
+    column_list=('name', 'status', 'duration', 'level', 'type', 'user'),
     column_searchable_list=('name',),
 )
 


### PR DESCRIPTION
@logston is reviewing talks and wanted to see the talk duration. He also
thought it would be useful to be able to filter by the duration and
status of the talk.
