### PR TITLE
Add bulk accept and reject for talks

### DIFF
--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -1,31 +1,60 @@
 """Admin for talk-related models."""
 
+from flask.ext.admin import actions
+from flask.ext.admin.contrib.sqla import ModelView
+
 from pygotham.admin.utils import model_view
+from pygotham.core import db
 from pygotham.talks import models
 
-__all__ = ('CategoryModelView', 'TalkModelView', 'TalkReviewModelView')
+__all__ = ('CategoryModelView', 'talk_model_view', 'TalkReviewModelView')
 
+CATEGORY = 'Talks'
+
+
+class TalkModelView(ModelView, actions.ActionsMixin):
+
+    """Admin view for :class:`~pygotham.models.Talk`."""
+
+    column_filters = ('status', 'duration', 'level')
+    column_list = ('name', 'status', 'duration', 'level', 'type', 'user')
+    column_searchable_list = ('name',)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.init_actions()
+
+    @actions.action(
+        'accept', 'Accept', 'Are you sure you want to accept selected models?')
+    def approve(self, talks):
+        for pk in talks:
+            talk = models.Talk.query.get(pk)
+            talk.status = 'accepted'
+        self.session.commit()
+
+    @actions.action(
+        'reject', 'Reject', 'Are you sure you want to reject selected models?')
+    def reject(self, talks):
+        for pk in talks:
+            talk = models.Talk.query.get(pk)
+            talk.status = 'rejected'
+        self.session.commit()
 
 CategoryModelView = model_view(
     models.Category,
     'Categories',
-    'Talks',
+    CATEGORY,
     form_columns=('name', 'slug'),
 )
 
-TalkModelView = model_view(
-    models.Talk,
-    'Talks',
-    'Talks',
-    column_filters=('status', 'duration', 'level'),
-    column_list=('name', 'status', 'duration', 'level', 'type', 'user'),
-    column_searchable_list=('name',),
-)
+talk_model_view = TalkModelView(
+    models.Talk, db.session, 'Talks', CATEGORY, 'talks')
+
 
 TalkReviewModelView = model_view(
     models.Talk,
     'Review',
-    'Talks',
+    CATEGORY,
     can_create=False,
     can_delete=False,
     column_list=('name', 'status', 'level', 'type', 'user'),


### PR DESCRIPTION
In order to add custom actions to an admin view, `ActionxMixin` needs to
be a base class for the view class. The `model_view` function doesn't
allow for custom inheritance, and getting it to work would have been
tricky because the views require a method to go with each action.

To get this behavior to work, `TalkModelView` is being changed to a
class (as the name always suggested) with `talk_model_view` becoming the
instantiated version. It provides views to either accept or reject a
batch of talks.
