### PR TITLE
Hide empty abstract section

### DIFF
--- a/pygotham/frontend/templates/talks/detail.html
+++ b/pygotham/frontend/templates/talks/detail.html
@@ -20,7 +20,9 @@
     <h3>Description</h3>
     {{ talk.description|rst|safe }}
 
-    <h3>Abstract</h3>
-    {{ talk.abstract|rst|safe }}
+    {% if talk.abstract %}
+      <h3>Abstract</h3>
+      {{ talk.abstract|rst|safe }}
+    {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
Since abstract isn't a required field for talks there is the possibility
that there won't be any content under the "Abstract" heading on the talk
detail page. This change will only show the header when there is content
to show.
