### PR TITLE
Don't redirect from talk list when no talks

### DIFF
--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -42,10 +42,7 @@ def index():
     if not event.talks_are_published:
         abort(404)
 
-    if not event.accepted_talks.count():
-        return redirect('home.index')
-    else:
-        return render_template('talks/index.html', talks=event.accepted_talks)
+    return render_template('talks/index.html', talks=event.accepted_talks)
 
 
 @route(


### PR DESCRIPTION
Before I had the idea to add the `Event.talk_list_begins` property I
figured I'd redirect back to the home page when there were no accepted
talks. With the property this behavior isn't really needed. I was
reminded of it because the redirect was missing the `url_for`.
