### PR TITLE
Add speaker profiles

### DIFF
--- a/pygotham/frontend/speakers.py
+++ b/pygotham/frontend/speakers.py
@@ -1,0 +1,25 @@
+"""PyGotha speakers."""
+
+from flask import abort, Blueprint, render_template
+
+from pygotham.events import get_current as get_current_event
+from pygotham.frontend import route
+from pygotham.models import User
+
+__all__ = ('blueprint',)
+
+blueprint = Blueprint('speakers', __name__, url_prefix='/speakers')
+
+
+@route(blueprint, '/profile/<int:pk>')
+def profile(pk):
+    """Return the speaker profile view."""
+    event = get_current_event()
+    if not event.talks_are_published:
+        abort(404)
+
+    user = User.query.get_or_404(pk)
+    if not user.has_accepted_talks:
+        abort(404)
+
+    return render_template('speakers/profile.html', user=user)

--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -441,3 +441,8 @@ footer a {
   overflow: auto;
   padding: 15px;
 }
+
+.speaker .presentations {
+  list-style: none;
+  margin: 0;
+}

--- a/pygotham/frontend/templates/speakers/profile.html
+++ b/pygotham/frontend/templates/speakers/profile.html
@@ -1,0 +1,21 @@
+{% extends 'layouts/base.html' %}
+
+{% block title %}{{ user }} - Profile - {{ super() }}{% endblock %}
+
+{% block body_class %}{{ super() }} speaker{% endblock %}
+
+{% block main %}
+  <div class="row">
+    <h1>{{ user }}</h1>
+
+    {{ user.bio|rst|safe }}
+
+    <h3>Presentations</h3>
+
+    <ul class="presentations">
+      {% for talk in user.accepted_talks %}
+        <li><a href="{{ url_for('talks.detail', pk=talk.id) }}">{{ talk }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endblock %}

--- a/pygotham/frontend/templates/talks/detail.html
+++ b/pygotham/frontend/templates/talks/detail.html
@@ -6,7 +6,11 @@
   <div class="row">
     <h1>{{ talk }}</h1>
 
-    <h4>{{ talk.user }}</h4>
+    <h4>
+      <a href="{{ url_for('speakers.profile', pk=talk.user.id) }}">
+        {{ talk.user }}
+      </a>
+    </h4>
 
     <dl>
       <dt>Audience level:

--- a/pygotham/users/models.py
+++ b/pygotham/users/models.py
@@ -1,8 +1,10 @@
 """Users models."""
 
+from cached_property import cached_property
 from flask.ext.security import RoleMixin, UserMixin
 
 from pygotham.core import db
+from pygotham.talks.models import Talk
 
 __all__ = ('Role', 'User')
 
@@ -76,3 +78,13 @@ class User(db.Model, UserMixin):
 
     def __ne__(self, other):
         return self.id != getattr(other, 'id', None)
+
+    @cached_property
+    def accepted_talks(self):
+        """Return the user's accepted talks."""
+        return self.talks.filter(Talk.status == 'accepted').order_by(Talk.name)
+
+    @cached_property
+    def has_accepted_talks(self):
+        """Return whether the user has accepted talks."""
+        return self.accepted_talks.count() > 0


### PR DESCRIPTION
In addition to adding the view and template for the speaker profiles,
the `User` model is getting a couple of properties. The first property,
`accepted_talks`, returns all of a user's accepted talks. The second
property, `has_accepted_talks`, utilizes the first to indicate whether
or not a user has accepted talks.
