### PR TITLE
Use session set by the sponsor application form

### DIFF
--- a/pygotham/frontend/sponsors.py
+++ b/pygotham/frontend/sponsors.py
@@ -3,8 +3,8 @@
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask.ext.login import current_user
 from flask.ext.security import login_required
+from sqlalchemy import inspect
 
-from pygotham.core import db
 from pygotham.frontend import direct_to_template, route
 from pygotham.models import Level, Sponsor
 
@@ -30,8 +30,10 @@ def apply():
         form.populate_obj(sponsor)
         sponsor.applicant_id = current_user.id
 
-        db.session.add(sponsor)
-        db.session.commit()
+        # form.populate_obj already associated the instance with a
+        # session.
+        session = inspect(sponsor).session
+        session.commit()
 
         flash('Your application has been submitted.', 'success')
 


### PR DESCRIPTION
When populating the sponsor instance with `form.populate_obj`, the
instance becomes associated with a session. Because of this, calling
`db.session.add` results in `sqlalchemy.exc.InvalidRequestError` because
the sponsor level instance is already attached to a session.

Rather than trying to add the sponsor instance to another session and
committing it, `commit` needs to be called from the instance's session.

Fixes #52
