### PR TITLE
Show sponsorship applications on dashboard

### DIFF
--- a/pygotham/frontend/profile.py
+++ b/pygotham/frontend/profile.py
@@ -6,7 +6,7 @@ from flask.ext.security import login_required
 
 from pygotham.core import db
 from pygotham.frontend import route
-from pygotham.models import Talk
+from pygotham.models import Sponsor, Talk
 
 __all__ = ('blueprint',)
 
@@ -17,8 +17,10 @@ blueprint = Blueprint('profile', __name__, url_prefix='/profile')
 @login_required
 def dashboard():
     """Return the user's dashboard."""
+    sponsors = Sponsor.query.filter(Sponsor.applicant == current_user)
     talks = Talk.query.filter(Talk.user == current_user)
-    return render_template('profile/dashboard.html', talks=talks)
+    return render_template(
+        'profile/dashboard.html', talks=talks, sponsors=sponsors)
 
 
 @route(blueprint, '/settings', methods=('GET', 'POST'))

--- a/pygotham/frontend/templates/profile/dashboard.html
+++ b/pygotham/frontend/templates/profile/dashboard.html
@@ -3,34 +3,72 @@
 {% block title %}Dashboard - {{ super() }}{% endblock %}
 
 {% block main %}
-  <div class="row">
-    <div class="large-12 columns">
-      <h2>Your Proposals</h2>
-      <table class="proposals">
-        <thead>
-          <tr>
-            <th>Title</th>
-            <th>Type</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for talk in talks %}
+  {% if talks %}
+    <div class="row">
+      <div class="large-12 columns">
+        <h2>Your Proposals</h2>
+        <table class="proposals">
+          <thead>
             <tr>
-              <td>
-                {{ talk }}
-                {% if talk.is_accepted and current_event.talks_are_published %}
-                  <span class="label radius">accepted</span>
-                {% endif %}
-              </td>
-              <td>{{ talk.type }}</td>
-              <td>
-                <a href="{{ url_for('talks.edit', pk=talk.id) }}" class="button tiny radius">Edit</a>
-              </td>
+              <th>Title</th>
+              <th>Type</th>
+              <th>Actions</th>
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for talk in talks %}
+              <tr>
+                <td>
+                  {{ talk }}
+                  {% if talk.is_accepted and current_event.talks_are_published %}
+                    <span class="label radius">accepted</span>
+                  {% endif %}
+                </td>
+                <td>{{ talk.type }}</td>
+                <td>
+                  <a href="{{ url_for('talks.edit', pk=talk.id) }}" class="button tiny radius">Edit</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  {% endif %}
+
+  {% if sponsors %}
+    <div class="row">
+      <div class="large-12 columns">
+        <h2>Your Sponsorship Applications</h2>
+        <table class="sponsorships">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Level</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for sponsor in sponsors %}
+              <tr>
+                <td>{{ sponsor }}</td>
+                <td>{{ sponsor.level }}</td>
+                <td>
+                  {% if sponsor.accepted %}
+                    <span class="label radius">accepted</span>
+                  {% else %}
+                    <span class="label radius secondary">pending</span>
+                  {% endif %}
+                </td>
+                <td>
+                  <a href="{{ url_for('sponsors.edit', pk=sponsor.id) }}" class="button tiny radius">Edit</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/pygotham/frontend/templates/sponsors/edit.html
+++ b/pygotham/frontend/templates/sponsors/edit.html
@@ -1,0 +1,26 @@
+{% extends 'layouts/base.html' %}
+
+{% from 'foundation_wtf.html' import horizontal_field %}
+
+{% block title %}Sponsorship Update - {{ super() }}{% endblock %}
+
+{% block main %}
+  <div class="row">
+    <h1>Update Your Sponsorship Application</h1>
+
+    <form action="{{ url_for('sponsors.edit', pk=sponsor.id) }}" method="POST">
+      {{ form.hidden_tag() }}
+      {{ horizontal_field(form.name) }}
+      {{ horizontal_field(form.contact_name) }}
+      {{ horizontal_field(form.contact_email) }}
+      <div class="btn-group">
+        <button type="submit" class="btn btn-primary">Update</button>
+        <p>
+          By submitting a sponsorship application you are agreeing to the
+          <a href="{{ url_for('sponsors.terms') }}">terms and
+          conditions</a>.
+        </p>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/pygotham/sponsors/forms.py
+++ b/pygotham/sponsors/forms.py
@@ -7,7 +7,7 @@ from wtforms_alchemy import model_form_factory
 
 from pygotham.models import Level, Sponsor
 
-__all__ = ('SponsorApplicationForm',)
+__all__ = ('SponsorApplicationForm', 'SponsorEditForm')
 
 ModelForm = model_form_factory(Form)
 
@@ -17,6 +17,28 @@ class SponsorApplicationForm(ModelForm):
     """Form for creating :class:`~pygotham.models.Sponsor` instances."""
 
     level = QuerySelectField(query_factory=Level.query.all)
+
+    class Meta:
+        model = Sponsor
+        only = ('name', 'contact_name', 'contact_email')
+        field_args = {
+            'name': {'label': 'Sponsor Name'},
+            'contact_name': {'label': 'Contact Name'},
+            'contact_email': {
+                'label': 'Contact Email',
+                'validators': (Email(),),
+            },
+        }
+
+
+class SponsorEditForm(ModelForm):
+
+    """Form for editing :class:`~pygotham.models.Sponsor` instances.
+
+    The difference between this and
+    :class:`~pygotham.forms.SponsorApplicationForm` is that this form
+    does not allow ``level`` to be edited.
+    """
 
     class Meta:
         model = Sponsor


### PR DESCRIPTION
After a sponsor has submitted an application, they may want to update
some details. This new form will let them update the contact information
by first visiting their dashboard.

To help make the dashboard a little easier on the eye, some of the
styles being used on the page are being updated. The most important
thing to know about these changes is that there will be more of a
distinction between the styles of buttons and labels.
