### PR TITLE
Add presentation times to talk detail page

### DIFF
--- a/pygotham/frontend/templates/talks/detail.html
+++ b/pygotham/frontend/templates/talks/detail.html
@@ -6,6 +6,10 @@
   <div class="row">
     <h1>{{ talk }}</h1>
 
+    {% if talk.presentation %}
+      <small>{{ talk.presentation.slot }}</small>
+    {% endif %}
+
     <h4>
       <a href="{{ url_for('speakers.profile', pk=talk.user.id) }}">
         {{ talk.user }}

--- a/pygotham/schedule/models.py
+++ b/pygotham/schedule/models.py
@@ -164,9 +164,10 @@ class Slot(db.Model):
 
     def __str__(self):
         """Return a printable representation."""
-        date = self.start.strftime('%I:%M %p')
+        start = self.start.strftime('%I:%M %p')
+        end = self.end.strftime('%I:%M %p')
         rooms = ', '.join(map(str, self.rooms))
-        return '{} in {} on {}'.format(date, rooms, self.day)
+        return '{} - {} on {}, {}'.format(start, end, self.day, rooms)
 
     @cached_property
     def duration(self):


### PR DESCRIPTION
The times of a talk's presentation should be available when viewing its
detail page. This is especially important because slot's end times are
not available on the schedule page.

In addition to adding the times to the page, the string representation
of `Slot` are being adjusted slightly to both include the end time and
read a little easier.

Some style work needs to be done to make the time look nicer on the
page.

Closes #62
