### PR TITLE
Allow rst to be used in content_override, don't display anchors as block

### DIFF
--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -232,10 +232,6 @@ table.schedule td.presentation {
   text-align: center;
 }
 
-table.schedule td.presentation a {
-  display: block;
-}
-
 /* Jumbotron*/
 
 .jumbotron {

--- a/pygotham/frontend/templates/talks/schedule.html
+++ b/pygotham/frontend/templates/talks/schedule.html
@@ -26,7 +26,7 @@
                 {% for slot in row['slots'] %}
                   <td class="presentation slot-{{ slot.kind }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
                     {% if slot.content_override %}
-                      {{ slot.content_override }}
+                      {{ slot.content_override|rst|safe }}
                     {% elif slot.presentation %}
                       <a href="{{ url_for('talks.detail', pk=slot.presentation.talk.id) }}">
                         {{ slot.presentation }}


### PR DESCRIPTION
I'm not sure why we had the `display: block` in there. If anyone has a reason to keep that, please reject this PR.
