### PR TITLE
Use display block on a.block instead of just a

### DIFF
--- a/pygotham/frontend/static/css/screen.css
+++ b/pygotham/frontend/static/css/screen.css
@@ -232,7 +232,7 @@ table.schedule td.presentation {
   text-align: center;
 }
 
-table.schedule td.presentation a {
+table.schedule td.presentation a.block {
   display: block;
 }
 

--- a/pygotham/frontend/templates/talks/schedule.html
+++ b/pygotham/frontend/templates/talks/schedule.html
@@ -28,7 +28,7 @@
                     {% if slot.content_override %}
                       {{ slot.content_override|rst|safe }}
                     {% elif slot.presentation %}
-                      <a href="{{ url_for('talks.detail', pk=slot.presentation.talk.id) }}">
+                      <a href="{{ url_for('talks.detail', pk=slot.presentation.talk.id) }}" class="block">
                         {{ slot.presentation }}
                       </a>
                       {{ slot.presentation.talk.user }}


### PR DESCRIPTION
Restrict usage of `display: block` to allow regular use of links in presentation table cell content
