### PR TITLE
Hide the presentation in the talk admin

### DIFF
--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -19,6 +19,7 @@ class TalkModelView(ModelView, actions.ActionsMixin):
     column_filters = ('status', 'duration', 'level')
     column_list = ('name', 'status', 'duration', 'level', 'type', 'user')
     column_searchable_list = ('name',)
+    form_excluded_columns = ('presentation',)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Editing a talk's presentation outside of the schedule's section of the
admin is likely to lead to unexpected results. Excluding the
presentation field from the talk admin will hopefully prevent bad things
from happening.
