### PR TITLE
Add management command to create admin users

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,9 +4,10 @@ from flask.ext.migrate import MigrateCommand
 from flask.ext.script import Manager
 
 from pygotham.factory import create_app
-from pygotham.manage import CreateUser
+from pygotham.manage import CreateAdmin, CreateUser
 
 manager = Manager(create_app(__name__, ''))
+manager.add_command('create_admin', CreateAdmin())
 manager.add_command('create_user', CreateUser())
 manager.add_command('db', MigrateCommand)
 

--- a/pygotham/manage/users.py
+++ b/pygotham/manage/users.py
@@ -2,23 +2,25 @@
 
 import sys
 
+from flask import current_app
 from flask.ext.script import Command, prompt, prompt_pass
 from flask.ext.security.forms import RegisterForm
 from flask.ext.security.registerable import register_user
 from werkzeug.datastructures import MultiDict
 
 
-class CreateUser(Command):
+class RegisterUserMixin:
 
-    """Management command to create a :class:`~pygotham.models.User`."""
+    """Mixin that provides functionality to register new users."""
 
-    def run(self):
-        """Run the command."""
+    def register_user(self):
+        """Prompt for user details."""
         # Get the information.
         email = prompt('Email')
         name = prompt('Name')
         password = prompt_pass('Password')
         password_confirm = prompt_pass('Confirm Password')
+
         data = MultiDict({
             'email': email,
             'password': password,
@@ -30,13 +32,53 @@ class CreateUser(Command):
         if form.validate():
             # Register the new user.
             user = register_user(name=name, email=email, password=password)
+
             print('\nUser created successfully.')
             print('User(id={} email={})'.format(user.id, user.email))
 
-            return
+            return user
 
         # If something went wrong, report it and exit out.
         print('\nError creating user:')
         for errors in form.errors.values():
             print('\n'.join(errors))
         sys.exit(1)
+
+
+class CreateAdmin(Command, RegisterUserMixin):
+
+    """Management command to create a :class:`~pygotham.models.User`.
+
+    Users created through this command will have the ``admin`` role
+    associated with them.
+    """
+
+    def run(self):
+        """Run the command."""
+        user = self.register_user()
+
+        if user:
+            # Add the new user to the admin role.
+            datastore = current_app.extensions['security'].datastore
+            role = datastore.find_or_create_role(
+                'admin', description='Administrator')
+            datastore.add_role_to_user(user, role)
+
+            datastore.commit()
+
+            print('\nUser added to admins.')
+
+            return
+
+        # If something went wrong, report it and exit out.
+        print('\nError add user to admins')
+        sys.exit(1)
+
+
+class CreateUser(Command, RegisterUserMixin):
+
+    """Management command to create a :class:`~pygotham.models.User`."""
+
+    def run(self):
+        """Run the command."""
+        self.register_user()


### PR DESCRIPTION
One of the biggest points of confusion when setting up a new
installation of this project is how to create an admin user. The process
requires using the `create_user` management command and then issuing SQL
statements to create the admin role and add it to the new user.

This new management command takes care of all of that.

Because of the overlap in functionality between the `create_user` and
`create_admin` commands, a new class, `RegisterUserMixin`, is being
added.