### PR TITLE
Use version of slots admin already in production

### DIFF
--- a/pygotham/admin/schedule.py
+++ b/pygotham/admin/schedule.py
@@ -33,7 +33,11 @@ SlotModelView = model_view(
     'Slots',
     CATEGORY,
     column_default_sort='start',
-    column_list=('day', 'rooms', 'kind', 'start', 'end'),
+    column_filters=('day',),
+    column_list=(
+        'day', 'rooms', 'kind', 'start', 'end', 'presentation',
+        'content_override',
+    ),
     form_columns=('day', 'rooms', 'kind', 'start', 'end', 'content_override'),
 )
 


### PR DESCRIPTION
While building the schedule for the conference, the admin view for
`schedule.models.Slot` was changed in production* to figure out what
implementation made the most sense. This formalizes it as the preferred
version.

Closes #111

*Don't do this at home.