### PR TITLE
Replace generates with observes

### DIFF
--- a/pygotham/news/models.py
+++ b/pygotham/news/models.py
@@ -1,7 +1,7 @@
 """News models."""
 
 from slugify import slugify
-from sqlalchemy_utils.decorators import generates
+from sqlalchemy_utils import observes
 from sqlalchemy_utils.types.arrow import ArrowType
 
 from pygotham.core import db
@@ -27,7 +27,7 @@ class Announcement(db.Model):
         """Return a printable representation."""
         return self.title
 
-    @generates(slug)
-    def _create_slug(self):
-        """Return the slug for the announcement."""
-        return slugify(self.title)
+    @observes('title')
+    def _create_slug(self, title):
+        """Create a slug from the title of the announcement."""
+        self.slug = slugify(self.title)


### PR DESCRIPTION
SQLAlchemy-Utils deprecated the `generates` decorator in version 0.28.0.
The decorator was removed in version 0.30.0. The use of it is being
replaced by the `observes` decorator which was added to SQLAlchemy-Utils
in version 0.28.0.

References #113