### PR TITLE
Add required fields to example_settings.cfg

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ The following folks have helped contribute to making this website possible.
 * Gloria W (`@gloriajw <https://github.com/gloriajw>`_)
 * Celia La (`@celiala <https://github.com/celiala>`_)
 * Paul Logston (`@logston <https://github.com/logston>`_)
+* Dean Silfen (`@deanrex <https://github.com/djds23>`_)

--- a/instance/example_settings.cfg
+++ b/instance/example_settings.cfg
@@ -1,6 +1,8 @@
 ASSETS_DEBUG = True
 DEBUG = True
 GOOGLE_ANALYTICS_PROFILE_ID = 'UA-123456-1'
+MAIL_DEFAULT_SENDER = 'default@for.pygotham'
+MAIL_SUPPRESS_SEND = True
 SECRET_KEY = 'abc123'
 SECURITY_PASSWORD_SALT = 'abc123'
 SQLALCHEMY_DATABASE_URI = 'postgresql://pygotham:pygotham@db/pygotham'


### PR DESCRIPTION
Without these fields the SMTP server would try to send out emails
to admins, with these fields everything works properly.