### PR TITLE
Make the recording release opt-out

### DIFF
--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -76,7 +76,8 @@ def proposal(pk=None):
             message = 'The Call for Proposals is closed at this time.'
             flash(message, 'warning')
             return redirect(url_for('home.index'))
-        talk = Talk(user_id=current_user.id, event=event)
+        talk = Talk(
+            user_id=current_user.id, event=event, recording_release=True)
         db.session.add(talk)
 
     form = TalkSubmissionForm(obj=talk)


### PR DESCRIPTION
The wording used on the page says the release is opt-out. This makes the
functionality match.

The change has to be implemented in this way because SQLAlchemy doesn't
use a column's default values until it's inserted into the database. The
`recording_release` column will start out with an initial value of
`None`. This means that even though WTForms-Alchemy will use a column's
default value, the `None` will override any default and result in the
checkbox not being checked.

Closes #97