### PR TITLE
Change how new talks are added to the session

### DIFF
--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -77,12 +77,13 @@ def proposal(pk=None):
             flash(message, 'warning')
             return redirect(url_for('home.index'))
         talk = Talk(
-            user_id=current_user.id, event=event, recording_release=True)
-        db.session.add(talk)
+            user_id=current_user.id, event_id=event.id, recording_release=True)
 
     form = TalkSubmissionForm(obj=talk)
     if form.validate_on_submit():
         form.populate_obj(talk)
+
+        db.session.add(talk)
         db.session.commit()
 
         flash('Your proposal has been submitted.', 'success')


### PR DESCRIPTION
Flask-SQLAlchemy turned on autoflush by default. With the upgrade in
9bb3c58, the new talk submission page started raising an exception when
trying to flush the session. There really is no need to add the talk to
the session until it's been populated. Unfortunately associating it with
an `Event` meant that it needed a session.

By passing `event_id` to `Talk()` instead of `event`, no session is
necessary until we're ready to insert the talk.