### PR TITLE
Add SQLAlchemy naming conventions

### DIFF
--- a/pygotham/core.py
+++ b/pygotham/core.py
@@ -8,6 +8,16 @@ from flask.ext.sqlalchemy import SQLAlchemy
 __all__ = ('db',)
 
 db = SQLAlchemy()
+# NOTE: It would be cleaner to simply pass in a MetaData object to SQLAlchemy.
+# Flask-SQLAlchemy supports this starting with version 2.1, which is not out at
+# the time of this writing.
+db.metadata.naming_convention = {
+    'ix': 'ix_%(column_0_label)s',
+    'uq': '%(table_name)s_%(column_0_name)s_key',
+    'ck': 'ck_%(table_name)s_%(constraint_name)s',
+    'fk': '%(table_name)s_%(column_0_name)s_fkey',
+    'pk': '%(table_name)s_pkey',
+}
 mail = Mail()
 migrate = Migrate()
 security = Security()


### PR DESCRIPTION
This ensures that all indecies, constraints, etc. will have proper names
when generating migrations via alembic's autogenerate functionality.

Note: conventions were chosen to match existing names.