### PR TITLE
Remove fields from submit a talk form

### DIFF
--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -77,7 +77,11 @@ def proposal(pk=None):
             flash(message, 'warning')
             return redirect(url_for('home.index'))
         talk = Talk(
-            user_id=current_user.id, event_id=event.id, recording_release=True)
+            user_id=current_user.id,
+            event_id=event.id,
+            recording_release=True,
+            type='talk',
+        )
 
     form = TalkSubmissionForm(obj=talk)
     if form.validate_on_submit():

--- a/pygotham/frontend/templates/talks/proposal.html
+++ b/pygotham/frontend/templates/talks/proposal.html
@@ -21,22 +21,7 @@
           {{ wtf.horizontal_field(form.level, placeholder='Level') }}
         </div>
         <div class="row">
-          {{ wtf.horizontal_field(form.type, placeholder='Type') }}
-        </div>
-        <div class="row">
           {{ wtf.horizontal_field(form.duration, placeholder='Duration') }}
-        </div>
-        <div class="row">
-          {{ wtf.horizontal_field(form.abstract, placeholder='Abstract') }}
-        </div>
-        <div class="row">
-          {{ wtf.horizontal_field(form.objectives, placeholder='Objectives') }}
-        </div>
-        <div class="row">
-          {{ wtf.horizontal_field(form.target_audience, placeholder='Audience') }}
-        </div>
-        <div class="row">
-          {{ wtf.horizontal_field(form.outline, placeholder='Outline') }}
         </div>
         <div class="row">
           {{ wtf.horizontal_field(form.additional_requirements, placeholder='Additional Requirements') }}

--- a/pygotham/talks/forms.py
+++ b/pygotham/talks/forms.py
@@ -23,7 +23,14 @@ class TalkSubmissionForm(ModelForm):
 
     class Meta:
         model = Talk
-        exclude = ('status',)
+        exclude = (
+            'abstract',
+            'objectives',
+            'outline',
+            'status',
+            'target_audience',
+            'type',
+        )
         field_args = {
             'name': {'label': 'Title'},
             'description': {
@@ -34,36 +41,7 @@ class TalkSubmissionForm(ModelForm):
                 ),
             },
             'level': {'label': 'Experience Level'},
-            'type': {'label': 'Type'},
             'duration': {'label': 'Duration'},
-            'abstract': {
-                'label': 'Abstract',
-                'description': (
-                    'Detailed overview. Will be made public if your talk is '
-                    'accepted.'
-                ),
-            },
-            'objectives': {
-                'label': 'Objectives',
-                'description': (
-                    'What do you hope to accomplish with this talk?'
-                ),
-            },
-            'target_audience': {
-                'label': 'Target Audience',
-                'description': (
-                    'Who is the intended audience for your talk? (Be '
-                    'specific; "Python programmers" is not a good answer to '
-                    'this question.)'
-                ),
-            },
-            'outline': {
-                'label': 'Outline',
-                'description': (
-                    'Sections and key points of the talk meant to give the '
-                    'committee an overview.'
-                ),
-            },
             'additional_requirements': {'label': 'Additional Requirements'},
             'recording_release': {
                 'label': 'Recording Release',


### PR DESCRIPTION
Removes several fields from the `/talks/new` as discussed in #131
to make a CFP easier. Adds a twitter handle to the user field.

Does not add 'tweet your talk' button yet. That is still
being worked on.