### PR TITLE
Allow AboutPage slugs to be set manually

### DIFF
--- a/pygotham/about/models.py
+++ b/pygotham/about/models.py
@@ -43,4 +43,5 @@ class AboutPage(db.Model):
     @observes('title')
     def _create_slug(self, title):
         """Create the slug for the page."""
-        self.slug = slugify(self.title)
+        if not self.slug:
+            self.slug = slugify(self.title)

--- a/pygotham/admin/about.py
+++ b/pygotham/admin/about.py
@@ -12,5 +12,5 @@ AboutPageModelView = model_view(
     'About',
     column_default_sort='title',
     column_list=('title', 'navbar_section', 'event', 'active'),
-    form_columns=('title', 'navbar_section', 'content', 'event', 'active'),
+    form_columns=('title', 'slug', 'navbar_section', 'content', 'event', 'active'),
 )


### PR DESCRIPTION
If the slug changes whenever an `AboutPage`'s title changes, URLs
bookmarked by users or indexed by search engines can break. There may
also be times when a slug that doesn't exactly match the title may be
desired.

By only setting the slug when it's empty and exposing the field in the
admin, this level of control is achieved.