### PR TITLE
Get an event's sponsors through sponsor levels

### DIFF
--- a/pygotham/sponsors/__init__.py
+++ b/pygotham/sponsors/__init__.py
@@ -1,5 +1,6 @@
 """Sponsors package."""
 
+from pygotham.events import get_current
 from pygotham.sponsors.models import Level, Sponsor
 
 __all__ = ('get_accepted',)
@@ -7,5 +8,7 @@ __all__ = ('get_accepted',)
 
 def get_accepted():
     """Get the accepted sponsors."""
-    return Sponsor.query.current.filter(
-        Sponsor.accepted == True).join(Level).order_by(Level.order).all()
+    return Sponsor.query.filter(
+        Sponsor.accepted == True,
+        Level.event == get_current(),
+    ).order_by(Level.order).all()

--- a/pygotham/sponsors/models.py
+++ b/pygotham/sponsors/models.py
@@ -48,7 +48,6 @@ class Sponsor(db.Model):
     """Sponsor."""
 
     __tablename__ = 'sponsors'
-    query_class = EventQuery
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(255), nullable=False)


### PR DESCRIPTION
`Sponsor` records are associated with an event through their level. As
such, the `EventQuery` doesn't make much sense (or work) with the model.
The correct way to get the accepted sponsors for an event includes
filtering by the event of the sponsorship level.