### PR TITLE
Prepend event_slug to all frontend URLs

### DIFF
--- a/pygotham/about/models.py
+++ b/pygotham/about/models.py
@@ -4,6 +4,7 @@ from slugify import slugify
 from sqlalchemy_utils import observes
 
 from pygotham.core import db
+from pygotham.events.query import EventQuery
 
 __all__ = ('AboutPage',)
 
@@ -12,6 +13,7 @@ class AboutPage(db.Model):
     """About page."""
 
     __tablename__ = 'about_pages'
+    query_class = EventQuery
 
     id = db.Column(db.Integer, primary_key=True)
     # TODO: validate that the navbar_section / slug combination do not conflict

--- a/pygotham/events/__init__.py
+++ b/pygotham/events/__init__.py
@@ -1,19 +1,1 @@
 """Events package."""
-
-import arrow
-from sqlalchemy import or_
-
-from pygotham.events.models import Event
-
-__all__ = ('get_current',)
-
-
-def get_current():
-    """Get the current event."""
-    now = arrow.utcnow().to('America/New_York').naive
-
-    return Event.query.filter(
-        Event.active == True,
-        or_(Event.activity_begins == None, Event.activity_begins <= now),
-        or_(Event.activity_ends == None, Event.activity_ends > now),
-    ).order_by(Event.activity_begins).first()

--- a/pygotham/events/query.py
+++ b/pygotham/events/query.py
@@ -1,3 +1,4 @@
+from flask import g
 from flask_sqlalchemy import BaseQuery
 
 
@@ -12,5 +13,4 @@ class EventQuery(BaseQuery):
     @property
     def current(self):
         # Circular import
-        from pygotham.events import get_current
-        return self.filter_by(event=get_current())
+        return self.filter_by(event=g.current_event)

--- a/pygotham/frontend/__init__.py
+++ b/pygotham/frontend/__init__.py
@@ -6,13 +6,16 @@ import importlib
 import pkgutil
 import os
 
-from flask import render_template, url_for
+from flask import g, render_template, url_for
 from flask.ext.assets import Bundle, Environment
 from flask.ext.foundation import Foundation
 from raven.contrib.flask import Sentry
+from sqlalchemy import or_
+
+import arrow
 
 from pygotham import factory, filters
-from pygotham.events import get_current as get_current_event
+from pygotham.events.models import Event
 
 __all__ = ('create_app', 'route')
 
@@ -60,9 +63,29 @@ def create_app(settings_override=None):
     assets.register('css_foundation', css_foundation)
     assets.register('js_foundation', js_foundation)
 
+    @app.url_defaults
+    def add_event_slug(endpoint, values):
+        if 'event_slug' in values or not g.current_event:
+            return
+        if app.url_map.is_endpoint_expecting(endpoint, 'event_slug'):
+            values['event_slug'] = g.current_event.slug
+
+    @app.url_value_preprocessor
+    def current_event_from_url(endpoint, values):
+        if values is None:
+            values = {}
+        if app.url_map.is_endpoint_expecting(endpoint, 'event_slug'):
+            now = arrow.utcnow().to('America/New_York').naive
+            g.current_event = Event.query.filter(
+                Event.slug == values.pop('event_slug', None),
+                Event.active == True,
+                or_(Event.activity_begins == None, Event.activity_begins <= now),
+                or_(Event.activity_ends == None, Event.activity_ends > now),
+            ).order_by(Event.activity_begins).first_or_404()
+
     @app.context_processor
     def current_event():
-        return {'current_event': get_current_event()}
+        return {'current_event': g.current_event}
 
     @app.context_processor
     def generate_navbar():

--- a/pygotham/frontend/about.py
+++ b/pygotham/frontend/about.py
@@ -4,19 +4,18 @@ from collections import defaultdict
 
 from flask import Blueprint, render_template, url_for
 
-from pygotham.events import get_current
 from pygotham.models import AboutPage
 
 __all__ = ('blueprint', 'get_nav_links')
 
-blueprint = Blueprint('about', __name__, url_prefix='/about')
+blueprint = Blueprint('about', __name__, url_prefix='/<event_slug>/about')
 
 
 def get_nav_links():
     """Generates all about page titles and urls for use in the navbar."""
     links = defaultdict(dict)
-    for page in AboutPage.query.filter_by(
-            active=True, event=get_current()).order_by(AboutPage.slug):
+    for page in AboutPage.query.current.filter_by(
+            active=True).order_by(AboutPage.slug):
         url = url_for('about.rst_content', slug=page.slug)
         links[page.navbar_section.lower()][page.title] = url
     return links
@@ -28,9 +27,8 @@ def rst_content(slug):
 
     :param slug: the uniquely identifying slug portion of the url
     """
-    page = AboutPage.query.filter_by(
+    page = AboutPage.query.current.filter_by(
         slug=slug,
         active=True,
-        event=get_current(),
     ).first_or_404()
     return render_template('about/rst.html', page=page)

--- a/pygotham/frontend/home.py
+++ b/pygotham/frontend/home.py
@@ -12,6 +12,7 @@ blueprint = Blueprint(
     __name__,
     static_folder='static',
     static_url_path='/frontend/static',
+    url_prefix='/<event_slug>'
 )
 
 

--- a/pygotham/frontend/profile.py
+++ b/pygotham/frontend/profile.py
@@ -10,7 +10,7 @@ from pygotham.models import Sponsor, Talk
 
 __all__ = ('blueprint',)
 
-blueprint = Blueprint('profile', __name__, url_prefix='/profile')
+blueprint = Blueprint('profile', __name__, url_prefix='/<event_slug>/profile')
 
 
 @route(blueprint, '/dashboard')

--- a/pygotham/frontend/registration.py
+++ b/pygotham/frontend/registration.py
@@ -6,7 +6,11 @@ from pygotham.frontend import direct_to_template
 
 __all__ = ('blueprint',)
 
-blueprint = Blueprint('registration', __name__, url_prefix='/registration')
+blueprint = Blueprint(
+    'registration',
+    __name__,
+    url_prefix='/<event_slug>/registration',
+)
 
 direct_to_template(
     blueprint, '/information', template='registration/information.html')

--- a/pygotham/frontend/speakers.py
+++ b/pygotham/frontend/speakers.py
@@ -1,21 +1,23 @@
 """PyGotha speakers."""
 
-from flask import abort, Blueprint, render_template
+from flask import abort, Blueprint, g, render_template
 
-from pygotham.events import get_current as get_current_event
 from pygotham.frontend import route
 from pygotham.models import User
 
 __all__ = ('blueprint',)
 
-blueprint = Blueprint('speakers', __name__, url_prefix='/speakers')
+blueprint = Blueprint(
+    'speakers',
+    __name__,
+    url_prefix='/<event_slug>/speakers',
+)
 
 
 @route(blueprint, '/profile/<int:pk>')
 def profile(pk):
     """Return the speaker profile view."""
-    event = get_current_event()
-    if not event.talks_are_published:
+    if not g.current_event.talks_are_published:
         abort(404)
 
     # TODO: Filter by event.

--- a/pygotham/frontend/sponsors.py
+++ b/pygotham/frontend/sponsors.py
@@ -13,7 +13,11 @@ from pygotham.models import Level, Sponsor
 
 __all__ = ('blueprint', 'get_nav_links')
 
-blueprint = Blueprint('sponsors', __name__, url_prefix='/sponsors')
+blueprint = Blueprint(
+    'sponsors',
+    __name__,
+    url_prefix='/<event_slug>/sponsors',
+)
 
 
 @route(blueprint, '/apply', methods=('GET', 'POST'))

--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -1,17 +1,17 @@
 """PyGotham talks."""
 
-from flask import abort, Blueprint, flash, redirect, render_template, url_for
+from flask import (abort, Blueprint, g, flash, redirect, render_template,
+                   url_for)
 from flask.ext.login import current_user
 from flask.ext.security import login_required
 
 from pygotham.core import db
-from pygotham.events import get_current as get_current_event
 from pygotham.frontend import direct_to_template, route
 from pygotham.models import Day, Talk
 
 __all__ = ('blueprint', 'get_nav_links')
 
-blueprint = Blueprint('talks', __name__, url_prefix='/talks')
+blueprint = Blueprint('talks', __name__, url_prefix='/<event_slug>/talks')
 
 direct_to_template(
     blueprint,
@@ -24,7 +24,7 @@ direct_to_template(
 @route(blueprint, '/<int:pk>')
 def detail(pk):
     """Return the talk detail view."""
-    event = get_current_event()
+    event = g.current_event
     if not event.talks_are_published:
         abort(404)
 
@@ -38,7 +38,7 @@ def detail(pk):
 @route(blueprint, '')
 def index():
     """Return the talk list."""
-    event = get_current_event()
+    event = g.current_event
     if not event.talks_are_published:
         abort(404)
 
@@ -62,7 +62,7 @@ def proposal(pk=None):
         flash(message, 'warning')
         return redirect(url_for('profile.settings'))
 
-    event = get_current_event()
+    event = g.current_event
 
     if pk:
         talk = Talk.query.filter(
@@ -107,7 +107,7 @@ direct_to_template(
 
 @route(blueprint, '/schedule')
 def schedule():
-    event = get_current_event()
+    event = g.current_event
     if not event.talks_are_published:
         abort(404)
 
@@ -121,7 +121,7 @@ def get_nav_links():
 
     Omits certain urls based on talk submission status.
     """
-    event = get_current_event()
+    event = g.current_event
     links = {
         # FIXME: CFP should probably be database-backed reST content
         'Call For Proposals': url_for('talks.call_for_proposals'),

--- a/pygotham/sponsors/__init__.py
+++ b/pygotham/sponsors/__init__.py
@@ -1,6 +1,7 @@
 """Sponsors package."""
 
-from pygotham.events import get_current
+from flask import g
+
 from pygotham.sponsors.models import Level, Sponsor
 
 __all__ = ('get_accepted',)
@@ -10,5 +11,5 @@ def get_accepted():
     """Get the accepted sponsors."""
     return Sponsor.query.filter(
         Sponsor.accepted == True,
-        Level.event == get_current(),
+        Level.event == g.current_event,
     ).order_by(Level.order).all()


### PR DESCRIPTION
Current event is now populated entirely by this identifier, so
`pygotham.events.get_current` is no longer needed.