### PR TITLE
Redirect the root URL to the current event

### DIFF
--- a/server/nginx/pygotham.org.conf
+++ b/server/nginx/pygotham.org.conf
@@ -32,6 +32,10 @@ server {
        }
 
        location / {
+           return 302 http://pygotham.org/2015/;
+       }
+
+       location /2015/ {
           uwsgi_pass unix:///usr/local/PyGotham/socket_dir_for_uwsgi/prod_socket;
           include uwsgi_params;
        }


### PR DESCRIPTION
This is being hardcoded to 2015. This may be how we do it from year to
year.

TODO: We need to set up 2014.