### PR TITLE
Make the nginx rules catch all URLs

### DIFF
--- a/server/nginx/pygotham.org.conf
+++ b/server/nginx/pygotham.org.conf
@@ -31,11 +31,11 @@ server {
            #add_header Last-Modified $sent_http_Expires;
        }
 
-       location / {
+       location = / {
            return 302 http://pygotham.org/2015/;
        }
 
-       location /2015/ {
+       location / {
           uwsgi_pass unix:///usr/local/PyGotham/socket_dir_for_uwsgi/prod_socket;
           include uwsgi_params;
        }


### PR DESCRIPTION
Rather than only matching URLs that begin with 2015 (a problem for the
admin), the redirect is being specified for only the root URL. This
allows all other URLs to go to uwsgi.

This takes care of other events as mentioned in 7000279 (although our
2014 is really going to be a static site).