### PR TITLE
Don't include other event's sponsors

### DIFF
--- a/pygotham/frontend/sponsors.py
+++ b/pygotham/frontend/sponsors.py
@@ -77,9 +77,9 @@ def edit(pk):
 def index():
     """Return the sponsors."""
     levels = Level.query.current.order_by(Level.order)
-    sponsors = Sponsor.query.filter(
-        Level.event == g.current_event,
+    sponsors = Sponsor.query.join(Level).filter(
         Sponsor.accepted == True,
+        Level.event == g.current_event,
     )
     has_sponsors = db.session.query(sponsors.exists()).scalar()
     return render_template(

--- a/pygotham/sponsors/__init__.py
+++ b/pygotham/sponsors/__init__.py
@@ -9,7 +9,7 @@ __all__ = ('get_accepted',)
 
 def get_accepted():
     """Get the accepted sponsors."""
-    return Sponsor.query.filter(
+    return Sponsor.query.join(Level).filter(
         Sponsor.accepted == True,
         Level.event == g.current_event,
     ).order_by(Level.order).all()


### PR DESCRIPTION
There are a couple of places where we look up sponsors for the current
event. The current query uses an outer join to join the sponsors and
levels tables. This happens when no explicit join is added to the query.
An explicit join is being added (`join(Level)`) to switch to an inner
join.

This will affect both the home page and the sponsors page.