### PR TITLE
Remove talk type from TalkSubmissionForm

### DIFF
--- a/pygotham/talks/forms.py
+++ b/pygotham/talks/forms.py
@@ -34,7 +34,6 @@ class TalkSubmissionForm(ModelForm):
                 ),
             },
             'level': {'label': 'Experience Level'},
-            'type': {'label': 'Type'},
             'duration': {'label': 'Duration'},
             'abstract': {
                 'label': 'Abstract',


### PR DESCRIPTION
This was another change made in 21540c0. I missed it when I reintroduced
the changes in 480660d.