### PR TITLE
Add create_event management command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,10 +4,11 @@ from flask.ext.migrate import MigrateCommand
 from flask.ext.script import Manager
 
 from pygotham.factory import create_app
-from pygotham.manage import CreateAdmin, CreateUser
+from pygotham.manage import CreateAdmin, CreateEvent, CreateUser
 
 manager = Manager(create_app(__name__, ''))
 manager.add_command('create_admin', CreateAdmin())
+manager.add_command('create_event', CreateEvent())
 manager.add_command('create_user', CreateUser())
 manager.add_command('db', MigrateCommand)
 

--- a/pygotham/events/forms.py
+++ b/pygotham/events/forms.py
@@ -1,0 +1,19 @@
+"""Events forms."""
+
+from flask_wtf import Form
+from wtforms_alchemy import model_form_factory
+
+from pygotham.models import Event
+
+__all__ = ('EventForm',)
+
+ModelForm = model_form_factory(Form)
+
+
+class EventForm(ModelForm):
+
+    """Form for creating :class:`~pygotham.models.Event` instances."""
+
+    class Meta:
+        model = Event
+        only = ('name', 'slug', 'begins', 'ends', 'proposals_begin', 'active')

--- a/pygotham/forms.py
+++ b/pygotham/forms.py
@@ -1,5 +1,6 @@
 """Convenience module for forms."""
 
+from pygotham.events.forms import *
 from pygotham.sponsors.forms import *
 from pygotham.talks.forms import *
 from pygotham.users.forms import *

--- a/pygotham/manage/__init__.py
+++ b/pygotham/manage/__init__.py
@@ -1,3 +1,4 @@
 """Management commands."""
 
+from pygotham.manage.events import *
 from pygotham.manage.users import *

--- a/pygotham/manage/events.py
+++ b/pygotham/manage/events.py
@@ -1,0 +1,60 @@
+"""Event-related management commands."""
+
+import sys
+
+from flask_script import Command, prompt, prompt_bool
+from werkzeug.datastructures import MultiDict
+
+from pygotham.core import db
+from pygotham.forms import EventForm
+from pygotham.models import Event
+
+
+class CreateEvent(Command):
+
+    """Management command to create an :class:`~pygotham.models.Event`.
+
+    In addition to asking for certain values, the event can also be
+    activated.
+    """
+
+    def run(self):
+        """Run the command."""
+        # Get the information.
+        name = prompt('Name')
+        slug = prompt('Slug (optional)')
+        begins = prompt('Event start date')
+        ends = prompt('Event end date')
+        proposals_begin = prompt('CFP start date')
+        active = prompt_bool('Activate the event')
+
+        data = MultiDict({
+            'name': name,
+            'slug': slug,
+            'begins': begins,
+            'ends': ends,
+            'proposals_begin': proposals_begin,
+            'active': active,
+        })
+
+        # Validate the form.
+        form = EventForm(data, csrf_enabled=False)
+        if form.validate():
+            # Save the new event.
+            event = Event()
+            form.populate_obj(event)
+
+            db.session.add(event)
+            db.session.commit()
+
+            print('\nEvent created successfully.')
+            print('Event(id={} slug={} name={})'.format(
+                event.id, event.slug, event.name))
+
+            return event
+
+        # If something went wrong, report it and exit out.
+        print('\nError creating event:')
+        for errors in form.errors.values():
+            print('\n'.join(errors))
+        sys.exit(1)


### PR DESCRIPTION
This adds a new management command called `create_event`. It handles
setting the fields that are required for an event to be functional. This
is especially important now that the current event is specified through
the URL. Without this command, there would be no way to access the
site's admin without creating the first event in the database directly.

Closes #150