### PR TITLE
Adjust how duration is shown when reviewing a talk

### DIFF
--- a/pygotham/admin/templates/talks/review.html
+++ b/pygotham/admin/templates/talks/review.html
@@ -5,7 +5,7 @@
 
   <h4>Level:</h4> {{ form.level.data|rst|safe }}
   <h4>Type:</h4> {{ form.type.data|rst|safe }}
-  <h4>Duration:</h4> {{ form.duration.data|rst|safe }}
+  <h4>Duration:</h4> {{ form.duration.data }}
 
   <h4>Description:</h4>
   {{ form.description.data|rst|safe }}


### PR DESCRIPTION
The duration of a talk is not set up to contain reStructuredText so
there's no reason to process it as such. The filter doesn't handle
relationships well, so a change needed to be made anyway.

Fixes #178