### PR TITLE
Handle the home page post-CFP

### DIFF
--- a/pygotham/events/models.py
+++ b/pygotham/events/models.py
@@ -92,6 +92,12 @@ class Event(db.Model):
         return True
 
     @property
+    def is_call_for_proposals_expired(self):
+        """Return whether the call for proposals has expired."""
+        now = arrow.utcnow().to('America/New_York').naive
+        return self.proposals_end and self.proposals_end.naive < now
+
+    @property
     def is_registration_active(self):
         """Return whether registration for an event is active.
 

--- a/pygotham/frontend/templates/home/index.html
+++ b/pygotham/frontend/templates/home/index.html
@@ -17,6 +17,10 @@
           <a href="{{ url_for('talks.call_for_proposals') }}">
             Call for proposals now open!
           </a>
+        {% elif current_event.is_call_for_proposals_expired %}
+          {% if current_event.is_registration_active %}
+            <a href="{{ current_event.registration_url }}">Registration is open!!</a>
+          {% endif %}
         {% else %}
           The call for proposals opens on
           {{ current_event.proposals_begin.strftime('%A, %B %-d') }}.  Be sure


### PR DESCRIPTION
With the current version of the home page template, the CFP open date is
shown whenever the CFP isn't active. That means it shows up after the
CFP closes. This will fall back on a message about registering.

The real fix here is to add announcements to the home page and feature
the most recent, but I want to make sure something will be in place
Monday morning after the CFP is over.