### PR TITLE
Add event-based filters to admin

### DIFF
--- a/pygotham/admin/about.py
+++ b/pygotham/admin/about.py
@@ -11,6 +11,7 @@ AboutPageModelView = model_view(
     'About Pages',
     'About',
     column_default_sort='title',
+    column_filters=('event',),
     column_list=('title', 'navbar_section', 'event', 'active'),
     form_columns=('title', 'slug', 'navbar_section', 'content', 'event', 'active'),
 )

--- a/pygotham/admin/news.py
+++ b/pygotham/admin/news.py
@@ -15,6 +15,7 @@ AnnouncementModelView = model_view(
     'Announcements',
     CATEGORY,
     column_default_sort='published',
+    column_filters=('event',),
     column_list=('title', 'published', 'active'),
     form_columns=('title', 'content', 'active', 'published'),
     form_overrides={
@@ -27,6 +28,7 @@ CallToActionModelView = model_view(
     'Calls to Action',
     CATEGORY,
     column_default_sort='begins',
+    column_filters=('event',),
     column_list=('title', 'event', 'begins', 'ends', 'active'),
     form_columns=('title', 'url', 'event', 'begins', 'ends', 'active'),
     form_overrides={

--- a/pygotham/admin/schedule.py
+++ b/pygotham/admin/schedule.py
@@ -14,6 +14,7 @@ DayModelView = model_view(
     'Days',
     CATEGORY,
     column_default_sort='date',
+    column_filters=('event',),
     column_list=('date', 'event'),
     form_columns=('event', 'date'),
 )
@@ -33,7 +34,7 @@ SlotModelView = model_view(
     'Slots',
     CATEGORY,
     column_default_sort='start',
-    column_filters=('day',),
+    column_filters=('day', 'day.event'),
     column_list=(
         'day', 'rooms', 'kind', 'start', 'end', 'presentation',
         'content_override',

--- a/pygotham/admin/sponsors.py
+++ b/pygotham/admin/sponsors.py
@@ -13,6 +13,7 @@ LevelModelView = model_view(
     'Levels',
     CATEGORY,
     column_default_sort=('order', 'name'),
+    column_filters=('event',),
     column_list=('name', 'order', 'event'),
     form_columns=('name', 'description', 'cost', 'order', 'limit', 'event'),
 )
@@ -22,7 +23,7 @@ SponsorModelView = model_view(
     models.Sponsor,
     'Sponsors',
     CATEGORY,
-    column_filters=('level', 'accepted'),
+    column_filters=('level', 'accepted', 'level.event'),
     column_list=(
         'name', 'level', 'contact_name', 'contact_email', 'accepted',
         'payment_received',

--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -16,7 +16,7 @@ class TalkModelView(ModelView, actions.ActionsMixin):
 
     """Admin view for :class:`~pygotham.models.Talk`."""
 
-    column_filters = ('status', 'duration', 'level')
+    column_filters = ('status', 'duration', 'level', 'event')
     column_list = ('name', 'status', 'duration', 'level', 'type', 'user')
     column_searchable_list = ('name',)
     form_excluded_columns = ('presentation',)
@@ -66,6 +66,7 @@ TalkReviewModelView = model_view(
     CATEGORY,
     can_create=False,
     can_delete=False,
+    column_filters=('event',),
     column_list=('name', 'status', 'level', 'type', 'user'),
     column_searchable_list=('name',),
     edit_template='talks/review.html',


### PR DESCRIPTION
When viewing items in the admin, it can be cumbersome to figure out
which event an item belongs to. Event-based filters are being added to
the admin. Fortunately Flask-Admin has built-in support for filtering by
properties of a related model.

Closes #158