### PR TITLE
Simplify event filters in admin

### DIFF
--- a/pygotham/admin/about.py
+++ b/pygotham/admin/about.py
@@ -11,7 +11,7 @@ AboutPageModelView = model_view(
     'About Pages',
     'About',
     column_default_sort='title',
-    column_filters=('event',),
+    column_filters=('event.slug', 'event.name'),
     column_list=('title', 'navbar_section', 'event', 'active'),
     form_columns=('title', 'slug', 'navbar_section', 'content', 'event', 'active'),
 )

--- a/pygotham/admin/news.py
+++ b/pygotham/admin/news.py
@@ -15,7 +15,7 @@ AnnouncementModelView = model_view(
     'Announcements',
     CATEGORY,
     column_default_sort='published',
-    column_filters=('event',),
+    column_filters=('event.slug', 'event.name'),
     column_list=('title', 'published', 'active'),
     form_columns=('title', 'content', 'active', 'published'),
     form_overrides={
@@ -28,7 +28,7 @@ CallToActionModelView = model_view(
     'Calls to Action',
     CATEGORY,
     column_default_sort='begins',
-    column_filters=('event',),
+    column_filters=('event.slug', 'event.name'),
     column_list=('title', 'event', 'begins', 'ends', 'active'),
     form_columns=('title', 'url', 'event', 'begins', 'ends', 'active'),
     form_overrides={

--- a/pygotham/admin/schedule.py
+++ b/pygotham/admin/schedule.py
@@ -14,7 +14,7 @@ DayModelView = model_view(
     'Days',
     CATEGORY,
     column_default_sort='date',
-    column_filters=('event',),
+    column_filters=('event.slug', 'event.name'),
     column_list=('date', 'event'),
     form_columns=('event', 'date'),
 )
@@ -34,7 +34,7 @@ SlotModelView = model_view(
     'Slots',
     CATEGORY,
     column_default_sort='start',
-    column_filters=('day', 'day.event'),
+    column_filters=('day', 'day.event.slug', 'day.event.name'),
     column_list=(
         'day', 'rooms', 'kind', 'start', 'end', 'presentation',
         'content_override',

--- a/pygotham/admin/sponsors.py
+++ b/pygotham/admin/sponsors.py
@@ -13,7 +13,7 @@ LevelModelView = model_view(
     'Levels',
     CATEGORY,
     column_default_sort=('order', 'name'),
-    column_filters=('event',),
+    column_filters=('event.slug', 'event.name'),
     column_list=('name', 'order', 'event'),
     form_columns=('name', 'description', 'cost', 'order', 'limit', 'event'),
 )
@@ -23,7 +23,7 @@ SponsorModelView = model_view(
     models.Sponsor,
     'Sponsors',
     CATEGORY,
-    column_filters=('level', 'accepted', 'level.event'),
+    column_filters=('level', 'accepted', 'level.event.slug', 'level.event.name'),
     column_list=(
         'name', 'level', 'contact_name', 'contact_email', 'accepted',
         'payment_received',

--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -16,7 +16,7 @@ class TalkModelView(ModelView, actions.ActionsMixin):
 
     """Admin view for :class:`~pygotham.models.Talk`."""
 
-    column_filters = ('status', 'duration', 'level', 'event')
+    column_filters = ('status', 'duration', 'level', 'event.slug', 'event.name')
     column_list = ('name', 'status', 'duration', 'level', 'type', 'user')
     column_searchable_list = ('name',)
     form_excluded_columns = ('presentation',)
@@ -66,7 +66,7 @@ TalkReviewModelView = model_view(
     CATEGORY,
     can_create=False,
     can_delete=False,
-    column_filters=('event',),
+    column_filters=('event.slug', 'event.name'),
     column_list=('name', 'status', 'level', 'type', 'user'),
     column_searchable_list=('name',),
     edit_template='talks/review.html',


### PR DESCRIPTION
Rather than exposing all event properties when filtering, only the slug
and name fields should be used. These are the ones people are most
likely to use.