### PR TITLE
Change display of sponsor URLs

### DIFF
--- a/pygotham/filters.py
+++ b/pygotham/filters.py
@@ -1,5 +1,7 @@
 """Template filters for use across apps."""
 
+from urllib.parse import urlparse
+
 import bleach
 from docutils import core
 from wtforms.fields import HiddenField
@@ -9,6 +11,12 @@ __all__ = ('rst_to_html',)
 _ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'dl', 'dt', 'dd', 'cite',
 ]
+
+
+def clean_url(value):
+    """Return a URL without the schema and query string."""
+    parts = urlparse(value)
+    return parts.netloc + parts.path
 
 
 def is_hidden_field(field):

--- a/pygotham/frontend/templates/sponsors/index.html
+++ b/pygotham/frontend/templates/sponsors/index.html
@@ -29,7 +29,7 @@
                       <img src="{{ sponsor.logo }}" alt="{{ sponsor.name }}">
                     </a>
                     <h4>{{ sponsor }}</h4>
-                    <p><a href="{{ sponsor.url }}">{{ sponsor.url }}</a></p>
+                    <p><a href="{{ sponsor.url }}">{{ sponsor.url|clean_url }}</a></p>
                     {{ sponsor.description|rst|safe }}
                   </div>
                 </li>


### PR DESCRIPTION
Sometimes sponsors have ugly URLs. Rather than showing the whole thing,
a filter is being added to strip the scheme and query string from URLs.
It's being applied to the URLs as displayed on the sponsor page.