### PR TITLE
Use correct template block

### DIFF
--- a/pygotham/frontend/templates/speakers/profile.html
+++ b/pygotham/frontend/templates/speakers/profile.html
@@ -4,7 +4,7 @@
 
 {% block body_class %}{{ super() }} speaker{% endblock %}
 
-{% block main %}
+{% block content %}
   <div class="row">
     <h1>{{ user }}</h1>
 

--- a/pygotham/frontend/templates/sponsors/edit.html
+++ b/pygotham/frontend/templates/sponsors/edit.html
@@ -4,7 +4,7 @@
 
 {% block title %}Sponsorship Update - {{ super() }}{% endblock %}
 
-{% block main %}
+{% block content %}
   <div class="row">
     <h1>Update Your Sponsorship Application</h1>
 

--- a/pygotham/frontend/templates/talks/detail.html
+++ b/pygotham/frontend/templates/talks/detail.html
@@ -2,7 +2,7 @@
 
 {% block title %}Talk - {{ talk }} - {{ super() }}{% endblock %}
 
-{% block main %}
+{% block content %}
   <div class="row">
     <h1>{{ talk }}</h1>
 

--- a/pygotham/frontend/templates/talks/index.html
+++ b/pygotham/frontend/templates/talks/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Talk List - {{ super() }}{% endblock %}
 
-{% block main %}
+{% block content %}
   <div class="row">
     <h1>Accepted Talks</h1>
 

--- a/pygotham/frontend/templates/talks/recording-release.html
+++ b/pygotham/frontend/templates/talks/recording-release.html
@@ -2,7 +2,7 @@
 
 {% block title %}Recording Release - {{ super() }}{% endblock %}
 
-{% block main %}
+{% block content %}
   <div class="row">
     <h1>Recording Release</h1>
 

--- a/pygotham/frontend/templates/talks/schedule.html
+++ b/pygotham/frontend/templates/talks/schedule.html
@@ -2,7 +2,7 @@
 
 {% block title %}Talk Schedule - {{ super() }}{% endblock %}
 
-{% block main %}
+{% block content %}
   <div class="row">
     <div class="large-12 columns">
       <h1>Talk Schedule</h1>


### PR DESCRIPTION
The base template's content block was renamed in 5cdc514. These
templates weren't updated at the time. They're the remaining ones
according to ag.