### PR TITLE
Exclude volunteers from the event admin

### DIFF
--- a/pygotham/admin/events.py
+++ b/pygotham/admin/events.py
@@ -22,6 +22,7 @@ EventModelView = model_view(
         'days',
         'sponsor_levels',
         'talks',
+        'volunteers',
     ),
     form_overrides={
         'activity_begins': wtforms.DateTimeField,


### PR DESCRIPTION
Showing many-to-many relationships in the admin can cause a page to take
a while to load. Plus the event admin isn't really the place to manage
volunteers.

Closes #198