### PR TITLE
Include a talk's slug in its canonical URL

### DIFF
--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -23,8 +23,12 @@ direct_to_template(
 )
 
 
-@route(blueprint, '/<int:pk>')
-def detail(pk):
+# This route is being kept around for backward compatibility. It should
+# never be used directly.
+@route(
+    blueprint, '/<int:pk>', defaults={'slug': None}, endpoint='old_detail')
+@route(blueprint, '/<int:pk>/<slug>')
+def detail(pk, slug):
     """Return the talk detail view."""
     event = g.current_event
     if not event.talks_are_published:
@@ -34,6 +38,10 @@ def detail(pk):
         Talk.id == pk,
         Talk.event == event,
         Talk.status == 'accepted').first_or_404()
+
+    if slug != talk.slug:
+        return redirect(url_for('talks.detail', pk=pk, slug=talk.slug))
+
     return render_template('talks/detail.html', talk=talk)
 
 

--- a/pygotham/frontend/templates/speakers/profile.html
+++ b/pygotham/frontend/templates/speakers/profile.html
@@ -14,7 +14,11 @@
 
     <ul class="presentations">
       {% for talk in user.accepted_talks %}
-        <li><a href="{{ url_for('talks.detail', pk=talk.id) }}">{{ talk }}</a></li>
+        <li>
+          <a href="{{ url_for('talks.detail', pk=talk.id, slug=talk.slug) }}">
+            {{ talk }}
+          </a>
+        </li>
       {% endfor %}
     </ul>
   </div>

--- a/pygotham/frontend/templates/talks/index.html
+++ b/pygotham/frontend/templates/talks/index.html
@@ -9,7 +9,11 @@
     <ol class="accepted-talks">
       {% for talk in current_event.accepted_talks %}
         <li>
-          <h3><a href="{{ url_for('talks.detail', pk=talk.id) }}">{{ talk }}</a></h3>
+          <h3>
+            <a href="{{ url_for('talks.detail', pk=talk.id, slug=talk.slug) }}">
+              {{ talk }}
+            </a>
+          </h3>
           <h4>
             {{ talk.user }}
             {% if talk.category %} in {{ talk.category }} {% endif %}

--- a/pygotham/frontend/templates/talks/schedule.html
+++ b/pygotham/frontend/templates/talks/schedule.html
@@ -28,7 +28,7 @@
                     {% if slot.content_override %}
                       {{ slot.content_override|rst|safe }}
                     {% elif slot.presentation %}
-                      <a href="{{ url_for('talks.detail', pk=slot.presentation.talk.id) }}" class="title">
+                      <a href="{{ url_for('talks.detail', pk=slot.presentation.talk.id, slug=talk.slug) }}" class="title">
                         {{ slot.presentation }}
                       </a>
                       {{ slot.presentation.talk.user }}

--- a/pygotham/talks/models.py
+++ b/pygotham/talks/models.py
@@ -1,5 +1,7 @@
 """Talks models."""
 
+from slugify import slugify
+
 from pygotham.core import db
 from pygotham.events.query import EventQuery
 
@@ -100,3 +102,8 @@ class Talk(db.Model):
     def is_accepted(self):
         """Return whether the instance is accepted."""
         return self.status == 'accepted'
+
+    @property
+    def slug(self):
+        """Return a slug for the instance."""
+        return slugify(self.name, max_length=25)


### PR DESCRIPTION
Even though slug is tracked for talks, including it in the URL makes for
something that looks nicer and makes search engines happier. Because the
primary key is the important part of the URL, any URL with the correct
key will redirect to the canonical URL.

Closes #136