### PR TITLE
Omit / from sponsor domains with no path

### DIFF
--- a/pygotham/filters.py
+++ b/pygotham/filters.py
@@ -16,7 +16,7 @@ _ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
 def clean_url(value):
     """Return a URL without the schema and query string."""
     parts = urlparse(value)
-    return parts.netloc + parts.path
+    return parts.netloc + (parts.path if parts.path != '/' else '')
 
 
 def is_hidden_field(field):


### PR DESCRIPTION
Showing a trailing slash on a sponsor's domain when it's not part of a
path looks odd (e.g., example.org/). The `clean_url` is being altered to
only include the path when there's a path other than just root.