### PR TITLE
Tweak style of check for availability

### DIFF
--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -118,7 +118,7 @@ direct_to_template(
 @route(blueprint, '/schedule')
 def schedule():
     event = g.current_event
-    if not event.schedule_is_published and not current_user.has_role('admin'):
+    if not (event.schedule_is_published or current_user.has_role('admin')):
         abort(404)
 
     days = Day.query.filter(Day.event == event).order_by(Day.date)


### PR DESCRIPTION
Conditions with multiple nots can often be more difficult to follow. In
this case, the query can be (visually) simplified by using one not and
an or.

Closes #223