### PR TITLE
Hide presentation when schedule isn't published

### DIFF
--- a/pygotham/frontend/templates/talks/detail.html
+++ b/pygotham/frontend/templates/talks/detail.html
@@ -6,7 +6,7 @@
   <div class="row">
     <h1>{{ talk }}</h1>
 
-    {% if talk.presentation %}
+    {% if current_event.schedule_is_published and talk.presentation %}
       <small>{{ talk.presentation.slot }}</small>
     {% endif %}
 


### PR DESCRIPTION
No information about the schedule should be publicly available until the
schedule is published. Because of the rush to get the schedule live on
the site for PyGotham 2014, some corners were cut.

A talk's presentation slot information should only be available on the
detail page once the schedule for the event has been published.