### PR TITLE
Pad schedules times for pairwise iteration

### DIFF
--- a/pygotham/schedule/models.py
+++ b/pygotham/schedule/models.py
@@ -101,6 +101,12 @@ class Day(db.Model):
             return bisect_left(times, end) - times.index(start)
 
         times = sorted({slot.start for slot in self.slots})
+        # While we typically only care about the start times here, the
+        # list is iterated over two items at a time. Without adding a
+        # final element, the last time slot would be omitted. Any value
+        # could be used here as bisect_left only assumes the list is
+        # sorted, but using a meaningful value feels better.
+        times.append(self.slots[-1].end)
 
         slots = db.session.query(
             Slot.id,


### PR DESCRIPTION
When iteration over a schedule's times, we do so two items (start and
end) at a time. Since the list was being built with start times only,
the final time slot for each day was being omitted as the last start
time was used solely as an end time.

The final end time is being added to the end of the list so that the
correct number of pairwise iterations will happen.