### PR TITLE
Add trailing slashes to routes

### DIFF
--- a/pygotham/frontend/__init__.py
+++ b/pygotham/frontend/__init__.py
@@ -39,7 +39,7 @@ def create_app(settings_override=None):
     def current_event_from_url(endpoint, values):
         if values is None:
             values = {}
-        if app.url_map.is_endpoint_expecting(endpoint, 'event_slug'):
+        if endpoint and app.url_map.is_endpoint_expecting(endpoint, 'event_slug'):
             now = arrow.utcnow().to('America/New_York').naive
             g.current_event = Event.query.filter(
                 Event.slug == values.pop('event_slug', None),

--- a/pygotham/frontend/about.py
+++ b/pygotham/frontend/about.py
@@ -21,7 +21,7 @@ def get_nav_links():
     return links
 
 
-@blueprint.route('/<slug>')
+@blueprint.route('/<slug>/')
 def rst_content(slug):
     """Renders database-backed restructured text content as html pages.
 

--- a/pygotham/frontend/profile.py
+++ b/pygotham/frontend/profile.py
@@ -15,7 +15,7 @@ __all__ = ('blueprint',)
 blueprint = Blueprint('profile', __name__, url_prefix='/<event_slug>/profile')
 
 
-@route(blueprint, '/dashboard')
+@route(blueprint, '/dashboard/')
 @login_required
 def dashboard():
     """Return the user's dashboard."""
@@ -25,7 +25,7 @@ def dashboard():
         'profile/dashboard.html', talks=talks)
 
 
-@route(blueprint, '/settings', methods=('GET', 'POST'))
+@route(blueprint, '/settings/', methods=('GET', 'POST'))
 @login_required
 def settings():
     """Return the user's settings."""
@@ -46,7 +46,7 @@ def settings():
     return render_template('profile/settings.html', form=form)
 
 
-@route(blueprint, '/unvolunteer')
+@route(blueprint, '/unvolunteer/')
 @login_required
 def unvolunteer():
     """Remove a user from being a volunteer."""
@@ -59,7 +59,7 @@ def unvolunteer():
     return redirect(url_for('profile.dashboard'))
 
 
-@route(blueprint, '/volunteer')
+@route(blueprint, '/volunteer/')
 @login_required
 def volunteer():
     """Sign up a user as a volunteer."""

--- a/pygotham/frontend/registration.py
+++ b/pygotham/frontend/registration.py
@@ -13,7 +13,7 @@ blueprint = Blueprint(
 )
 
 direct_to_template(
-    blueprint, '/information', template='registration/information.html')
+    blueprint, '/information/', template='registration/information.html')
 
 
 def get_nav_links():

--- a/pygotham/frontend/speakers.py
+++ b/pygotham/frontend/speakers.py
@@ -14,7 +14,7 @@ blueprint = Blueprint(
 )
 
 
-@route(blueprint, '/profile/<int:pk>')
+@route(blueprint, '/profile/<int:pk>/')
 def profile(pk):
     """Return the speaker profile view."""
     if not g.current_event.talks_are_published:

--- a/pygotham/frontend/sponsors.py
+++ b/pygotham/frontend/sponsors.py
@@ -20,7 +20,7 @@ blueprint = Blueprint(
 )
 
 
-@route(blueprint, '/apply', methods=('GET', 'POST'))
+@route(blueprint, '/apply/', methods=('GET', 'POST'))
 @login_required
 def apply():
     """Return the sponsor application."""
@@ -49,7 +49,7 @@ def apply():
     return render_template('sponsors/apply.html', form=form)
 
 
-@route(blueprint, '/edit/<int:pk>', methods=('GET', 'POST'))
+@route(blueprint, '/edit/<int:pk>/', methods=('GET', 'POST'))
 @login_required
 def edit(pk):
     """Return the sponsor edit form."""
@@ -73,7 +73,7 @@ def edit(pk):
     return render_template('sponsors/edit.html', form=form, sponsor=sponsor)
 
 
-@route(blueprint, '')
+@route(blueprint, '/')
 def index():
     """Return the sponsors."""
     levels = Level.query.current.order_by(Level.order)
@@ -86,14 +86,14 @@ def index():
         'sponsors/index.html', levels=levels, has_sponsors=has_sponsors)
 
 
-@route(blueprint, '/prospectus')
+@route(blueprint, '/prospectus/')
 def prospectus():
     """Return the sponsorship prospectus."""
     levels = Level.query.current.order_by(Level.order)
     return render_template('sponsors/prospectus.html', levels=levels)
 
 
-direct_to_template(blueprint, '/terms', template='sponsors/terms.html')
+direct_to_template(blueprint, '/terms/', template='sponsors/terms.html')
 
 
 def get_nav_links():

--- a/pygotham/frontend/talks.py
+++ b/pygotham/frontend/talks.py
@@ -17,7 +17,7 @@ blueprint = Blueprint('talks', __name__, url_prefix='/<event_slug>/talks')
 
 direct_to_template(
     blueprint,
-    '/call-for-proposals',
+    '/call-for-proposals/',
     template='talks/call-for-proposals.html',
     endpoint='call_for_proposals',
 )
@@ -26,8 +26,8 @@ direct_to_template(
 # This route is being kept around for backward compatibility. It should
 # never be used directly.
 @route(
-    blueprint, '/<int:pk>', defaults={'slug': None}, endpoint='old_detail')
-@route(blueprint, '/<int:pk>/<slug>')
+    blueprint, '/<int:pk>/', defaults={'slug': None}, endpoint='old_detail')
+@route(blueprint, '/<int:pk>/<slug>/')
 def detail(pk, slug):
     """Return the talk detail view."""
     event = g.current_event
@@ -45,7 +45,7 @@ def detail(pk, slug):
     return render_template('talks/detail.html', talk=talk)
 
 
-@route(blueprint, '')
+@route(blueprint, '/')
 def index():
     """Return the talk list."""
     event = g.current_event
@@ -57,11 +57,11 @@ def index():
 
 @route(
     blueprint,
-    '/new',
+    '/new/',
     defaults={'pk': None},
     endpoint='submit',
     methods=('GET', 'POST'))
-@route(blueprint, '/<int:pk>/edit', endpoint='edit', methods=('GET', 'POST',))
+@route(blueprint, '/<int:pk>/edit/', endpoint='edit', methods=('GET', 'POST',))
 @login_required
 def proposal(pk=None):
     """Return the talk proposal form."""
@@ -109,13 +109,13 @@ def proposal(pk=None):
 
 direct_to_template(
     blueprint,
-    '/recording',
+    '/recording/',
     template='talks/recording-release.html',
     endpoint='recording_release',
 )
 
 
-@route(blueprint, '/schedule')
+@route(blueprint, '/schedule/')
 def schedule():
     event = g.current_event
     if not (event.schedule_is_published or current_user.has_role('admin')):


### PR DESCRIPTION
Rationale:

- Conceptually, this makes more sense in most of the current use cases.
  When using URLs like `/talks` and `/sponsors`, we typically refer to a
  list of documents rather than a single document. If we think about
  these as directories full of documents, a trailing slash should be
  used.

- Flask will redirect "branch" URLs missing their trailing slashes to
  their canonical equivalents (e.g. `/talks` --> `/talks/`), but the same
  is not true for the other direction (e.g. `/talks/` -/-> `/talks`) [0].
  This behavior is also seen in other web frameworks and when dealing with
  Unix files and directories.

- From a more practical archival standpoint, this makes creating a
  static backup of the site that can be served as a directory much
  easier.

A note on the change to frontend/__init__.py: Werkzeug raises a
RequestRedirect exception to handle the strict_slashes redirect. An
endpoint is not set until after the redirect happens, so the request
preprocessor function that sets `g.current_event` will raise an exception
if it attempts to use `None`.