### PR TITLE
Handle some static files through nginx

### DIFF
--- a/pygotham/frontend/static/robots.txt
+++ b/pygotham/frontend/static/robots.txt
@@ -1,0 +1,2 @@
+User-agents: *
+Disallow: /admin/

--- a/server/nginx/pygotham.org.conf
+++ b/server/nginx/pygotham.org.conf
@@ -27,6 +27,14 @@ server {
 
        index index.html index.htm;
 
+       location /favicon.ico {
+           return 404;
+       }
+
+       location /robots.txt {
+           alias /usr/local/PyGotham/prod/pygotham/frontend/static/robots.txt;
+       }
+
        location /static/ { # STATIC_URL
            alias /usr/local/PyGotham/prod/pygotham/frontend/static/; # STATIC_ROOT
            #expires modified 12h;


### PR DESCRIPTION
robots.txt and favicon.ico are files often requested by search engines
and browsers. Rather than letting nginx request these files from uWSGI,
nginx should handle them directly. Going forward it will serve the newly
added robots.txt and send a 404 for favicon.ico.