### PR TITLE
Make sure the correct pip is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.4.3
 WORKDIR /code
 COPY requirements.txt /code/
-RUN pip install -r requirements.txt
+RUN python -m pip install -r requirements.txt
 ADD . /code


### PR DESCRIPTION
Calling pip directly can sometimes result in installing libraries using
the wrong version of Python than expected. This can be preventing by
using the current preferred syntax of `python -m pip`.