### PR TITLE
Activate events added through management command

### DIFF
--- a/pygotham/manage/events.py
+++ b/pygotham/manage/events.py
@@ -2,6 +2,7 @@
 
 import sys
 
+import arrow
 from flask_script import Command, prompt, prompt_bool
 from werkzeug.datastructures import MultiDict
 
@@ -11,7 +12,6 @@ from pygotham.models import Event
 
 
 class CreateEvent(Command):
-
     """Management command to create an :class:`~pygotham.models.Event`.
 
     In addition to asking for certain values, the event can also be
@@ -43,6 +43,10 @@ class CreateEvent(Command):
             # Save the new event.
             event = Event()
             form.populate_obj(event)
+
+            if event.active:
+                now = arrow.utcnow().to('America/New_York').naive
+                event.activity_begins = now
 
             db.session.add(event)
             db.session.commit()


### PR DESCRIPTION
When marking an event as active, it won't be fully activated until the
activity begins date. The management command to add new events wasn't
set up to do this, which could be confusing for some people. The command
will now also set the `activity_begins` field to the current time when
its being marked as active.