### PR TITLE
Convert navbar to use Flask-Copilot

### DIFF
--- a/pygotham/core.py
+++ b/pygotham/core.py
@@ -1,5 +1,6 @@
 """Application core."""
 
+from flask_copilot import Copilot
 from flask_mail import Mail
 from flask_migrate import Migrate
 from flask_security import Security
@@ -7,6 +8,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 __all__ = ('db',)
 
+copilot = Copilot()
 db = SQLAlchemy()
 # NOTE: It would be cleaner to simply pass in a MetaData object to SQLAlchemy.
 # Flask-SQLAlchemy supports this starting with version 2.1, which is not out at

--- a/pygotham/factory.py
+++ b/pygotham/factory.py
@@ -3,7 +3,7 @@
 from flask import Flask
 from flask_security import SQLAlchemyUserDatastore
 
-from pygotham.core import db, mail, migrate, security
+from pygotham.core import copilot, db, mail, migrate, security
 from pygotham.models import Role, User
 from pygotham.utils import check_required_settings, register_blueprints
 
@@ -29,6 +29,7 @@ def create_app(package_name, package_path, settings_override=None,
 
     check_required_settings(app.config)
 
+    copilot.init_app(app)
     db.init_app(app)
     mail.init_app(app)
     migrate.init_app(app, db)

--- a/pygotham/frontend/about.py
+++ b/pygotham/frontend/about.py
@@ -1,24 +1,12 @@
 """About PyGotham."""
 
-from collections import defaultdict
-
-from flask import Blueprint, render_template, url_for
+from flask import Blueprint, render_template
 
 from pygotham.models import AboutPage
 
-__all__ = ('blueprint', 'get_nav_links')
+__all__ = ('blueprint',)
 
 blueprint = Blueprint('about', __name__, url_prefix='/<event_slug>/about')
-
-
-def get_nav_links():
-    """Generates all about page titles and urls for use in the navbar."""
-    links = defaultdict(dict)
-    for page in AboutPage.query.current.filter_by(
-            active=True).order_by(AboutPage.slug):
-        url = url_for('about.rst_content', slug=page.slug)
-        links[page.navbar_section.lower()][page.title] = url
-    return links
 
 
 @blueprint.route('/<slug>/')

--- a/pygotham/frontend/registration.py
+++ b/pygotham/frontend/registration.py
@@ -13,7 +13,11 @@ blueprint = Blueprint(
 )
 
 direct_to_template(
-    blueprint, '/information/', template='registration/information.html')
+    blueprint,
+    '/information/',
+    template='registration/information.html',
+    navbar_kwargs={'path': ('Registration', 'Information')},
+)
 
 
 def get_nav_links():

--- a/pygotham/frontend/sponsors.py
+++ b/pygotham/frontend/sponsors.py
@@ -11,7 +11,7 @@ from pygotham.core import db
 from pygotham.frontend import direct_to_template, route
 from pygotham.models import Level, Sponsor
 
-__all__ = ('blueprint', 'get_nav_links')
+__all__ = ('blueprint',)
 
 blueprint = Blueprint(
     'sponsors',
@@ -73,7 +73,7 @@ def edit(pk):
     return render_template('sponsors/edit.html', form=form, sponsor=sponsor)
 
 
-@route(blueprint, '/')
+@route(blueprint, '/', navbar_kwargs={'path': ('Sponsors', 'Sponsors')})
 def index():
     """Return the sponsors."""
     levels = Level.query.current.order_by(Level.order)
@@ -86,20 +86,17 @@ def index():
         'sponsors/index.html', levels=levels, has_sponsors=has_sponsors)
 
 
-@route(blueprint, '/prospectus/')
+@route(
+    blueprint,
+    '/prospectus/',
+    navbar_kwargs={'path': ('Sponsors', 'Sponsorship Prospectus')})
 def prospectus():
     """Return the sponsorship prospectus."""
     levels = Level.query.current.order_by(Level.order)
     return render_template('sponsors/prospectus.html', levels=levels)
 
 
+# TODO: Add this to the navbar.
+# FIXME: This content seems to be missing. Probably a template issue.
+# This is a good candidate for switching to an AboutPage.
 direct_to_template(blueprint, '/terms/', template='sponsors/terms.html')
-
-
-def get_nav_links():
-    """Return sponsor-related titles and urls for use in the navbar."""
-    links = {
-        'Sponsors': url_for('sponsors.index'),
-        'Sponsorship Prospectus': url_for('sponsors.prospectus'),
-    }
-    return {'Sponsors': links}

--- a/pygotham/frontend/templates/layouts/base.html
+++ b/pygotham/frontend/templates/layouts/base.html
@@ -28,14 +28,16 @@
 
       <section class="top-bar-section">
         <ul class="right">
-          {% for section, links in navbar %}
-            <li class="{{ section }} has-dropdown">
-              <a href="#">{{ section }}</a>
+          {% for entry in navbar %}
+          <li class="{{ entry.name }} {% if entry.children %}has-dropdown{% endif %}">
+              <a href="{{ entry.url() }}">{{ entry.name }}</a>
+              {% if entry.children %}
               <ul class="dropdown">
-                {% for link, url in links %}
-                <li><a href="{{ url }}">{{ link }}</a></li>
+                {% for child in entry.children %}
+                <li><a href="{{ child.url() }}">{{ child.name }}</a></li>
                 {% endfor %}
               </ul>
+              {% endif %}
             </li>
           {% endfor %}
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ cached-property
 docutils
 Flask==0.10.1
 Flask-Admin
+Flask-Copilot
 Flask-Login==0.2.11
 Flask-Mail
 Flask-Migrate

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,23 +14,24 @@ contextlib2==0.5.1        # via raven
 decorator==4.0.6          # via validators
 docutils==0.12
 Flask-Admin==1.4.0
-Flask-Login==0.2.11
-Flask-Mail==0.9.1
+flask-copilot==0.1.0
+Flask-Login==0.2.11       # via flask-security
+Flask-Mail==0.9.1         # via flask-security
 Flask-Migrate==1.7.0
-Flask-Principal==0.4.0
+Flask-Principal==0.4.0    # via flask-security
 Flask-RESTful==0.3.5
-Flask-Script==2.0.5
+Flask-Script==2.0.5       # via flask-migrate
 Flask-Security==1.7.4
-Flask-SQLAlchemy==2.1
-Flask-WTF==0.12
-Flask==0.10.1
+Flask-SQLAlchemy==2.1     # via flask-migrate
+Flask-WTF==0.12           # via flask-security
+Flask==0.10.1             # via flask-admin, flask-copilot, flask-login, flask-mail, flask-migrate, flask-principal, flask-restful, flask-script, flask-security, flask-sqlalchemy, flask-wtf
 html5lib==0.9999999       # via bleach
 infinity==1.3             # via intervals
 intervals==0.6.0          # via wtforms-components
 itsdangerous==0.24        # via flask, flask-security
-Jinja2==2.8
-Mako==1.0.3
-MarkupSafe==0.23
+Jinja2==2.8               # via flask
+Mako==1.0.3               # via alembic
+MarkupSafe==0.23          # via jinja2, mako
 passlib==1.6.5            # via flask-security
 psycopg2==2.6.1
 python-dateutil==2.4.2    # via aniso8601, arrow
@@ -39,11 +40,12 @@ python-slugify==1.2.0
 pytz==2015.7              # via flask-restful
 raven==5.10.2
 six==1.10.0               # via bleach, flask-restful, html5lib, python-dateutil, sqlalchemy-utils, validators, wtforms-alchemy, wtforms-components
-SQLAlchemy-Utils==0.31.6
-SQLAlchemy==1.0.11
-Unidecode==0.4.19
+sortedcontainers==1.4.4   # via flask-copilot
+SQLAlchemy-Utils==0.31.6  # via wtforms-alchemy
+SQLAlchemy==1.0.11        # via alembic, flask-sqlalchemy, sqlalchemy-utils, wtforms-alchemy
+Unidecode==0.4.19         # via python-slugify
 validators==0.10          # via wtforms-components
-Werkzeug==0.11.3
+Werkzeug==0.11.3          # via flask, flask-wtf
 WTForms-Alchemy==0.15.0
-WTForms-Components==0.10.0
-WTForms==2.1
+WTForms-Components==0.10.0  # via wtforms-alchemy
+WTForms==2.1              # via flask-admin, flask-wtf, wtforms-alchemy, wtforms-components


### PR DESCRIPTION
Replace custom and inflexible navbar generation code with Flask-Copilot.
Although this makes adjusting placement of navbar content easier, no
items are moved in this change (i.e. this is a strictly transparent port
with no desired functional side effects).

Fixes #219.