### PR TITLE
Display the time zone of the CFP close

### DIFF
--- a/pygotham/filters.py
+++ b/pygotham/filters.py
@@ -40,3 +40,9 @@ def rst_to_html(value, extra_tags=None):
         attributes=_ALLOWED_ATTRIBUTES,
         strip=True,
     )
+
+
+def time_zone(value):
+    """Return the local time zone for the given datetime."""
+    tz = value.to('America/New_York')
+    return tz.tzname()

--- a/pygotham/frontend/__init__.py
+++ b/pygotham/frontend/__init__.py
@@ -36,6 +36,7 @@ def create_app(settings_override=None):
     app.jinja_env.filters['clean_url'] = filters.clean_url
     app.jinja_env.filters['is_hidden_field'] = filters.is_hidden_field
     app.jinja_env.filters['rst'] = filters.rst_to_html
+    app.jinja_env.filters['time_zone'] = filters.time_zone
 
     if not app.debug:
         for e in (404, 500):

--- a/pygotham/frontend/templates/talks/call-for-proposals.html
+++ b/pygotham/frontend/templates/talks/call-for-proposals.html
@@ -9,10 +9,9 @@
     {% if current_event.proposals_end %}
       <div class="panel callout">
         <p>The Call for Proposals ends on
-        {{ current_event.proposals_end.strftime('%B') }}
-        {{ current_event.proposals_end.day }},
-        {{ current_event.proposals_end.year }}. Make sure you submit your talks
-        before then.</p>
+        {{ current_event.proposals_end.strftime('%A, %B %d, %Y') }}
+        {{ current_event.proposals_end|time_zone }}. Make sure you submit your
+        talks before then.</p>
       </div>
     {% endif %}
 


### PR DESCRIPTION
To help avoid confusion around when exactly the CFP ends, we want to
include the time zone on the CFP page.

To make this possible, a new filter named `time_zone` is being added.