### PR TITLE
Move the time zone to a setting

### DIFF
--- a/instance/example_settings.cfg
+++ b/instance/example_settings.cfg
@@ -6,3 +6,4 @@ MAIL_SUPPRESS_SEND = True
 SECRET_KEY = 'abc123'
 SECURITY_PASSWORD_SALT = 'abc123'
 SQLALCHEMY_DATABASE_URI = 'postgresql://pygotham:pygotham@db/pygotham'
+TIME_ZONE = 'America/New_York'

--- a/pygotham/events/models.py
+++ b/pygotham/events/models.py
@@ -2,6 +2,7 @@
 
 import arrow
 from cached_property import cached_property
+from flask import current_app
 from slugify import slugify
 from sqlalchemy_utils import observes
 from sqlalchemy_utils.types.arrow import ArrowType
@@ -85,7 +86,7 @@ class Event(db.Model):
         less than
         :attribute:`~pygotham.events.models.Event.proposals_end`.
         """
-        now = arrow.utcnow().to('America/New_York').naive
+        now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
         if not self.proposals_begin or now < self.proposals_begin.naive:
             return False
         if self.proposals_end and self.proposals_end.naive < now:
@@ -96,7 +97,7 @@ class Event(db.Model):
     @property
     def is_call_for_proposals_expired(self):
         """Return whether the call for proposals has expired."""
-        now = arrow.utcnow().to('America/New_York').naive
+        now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
         return self.proposals_end and self.proposals_end.naive < now
 
     @property
@@ -122,7 +123,7 @@ class Event(db.Model):
         if not self.registration_url:
             return False
 
-        now = arrow.utcnow().to('America/New_York').naive
+        now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
         begins = self.registration_begins
         if not begins or now < begins.naive:
             return False
@@ -135,7 +136,7 @@ class Event(db.Model):
     @property
     def schedule_is_published(self):
         """Return whether the schedule for an event is published."""
-        now = arrow.utcnow().to('America/New_York').naive
+        now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
         talk_schedule_begins = self.talk_schedule_begins
         if not talk_schedule_begins or talk_schedule_begins.naive > now:
             return False
@@ -144,7 +145,7 @@ class Event(db.Model):
     @property
     def talks_are_published(self):
         """Return whether the talk list for an event is published."""
-        now = arrow.utcnow().to('America/New_York').naive
+        now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
         if not self.talk_list_begins or self.talk_list_begins.naive > now:
             return False
         return True

--- a/pygotham/factory.py
+++ b/pygotham/factory.py
@@ -1,7 +1,7 @@
 """Application factory."""
 
 import arrow
-from flask import Flask, g
+from flask import current_app, Flask, g
 from flask_security import SQLAlchemyUserDatastore
 from sqlalchemy import or_
 
@@ -70,7 +70,7 @@ def create_app(package_name, package_path, settings_override=None,
             values = {}
         if endpoint and app.url_map.is_endpoint_expecting(
                 endpoint, 'event_slug'):
-            now = arrow.utcnow().to('America/New_York').naive
+            now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
             g.current_event = Event.query.filter(
                 Event.slug == values.pop('event_slug', None),
                 Event.active == True,  # NOQA

--- a/pygotham/filters.py
+++ b/pygotham/filters.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 import bleach
 from docutils import core
+from flask import current_app
 from wtforms.fields import HiddenField
 
 __all__ = ('rst_to_html',)
@@ -44,5 +45,5 @@ def rst_to_html(value, extra_tags=None):
 
 def time_zone(value):
     """Return the local time zone for the given datetime."""
-    tz = value.to('America/New_York')
+    tz = value.to(current_app.config['TIME_ZONE'])
     return tz.tzname()

--- a/pygotham/manage/events.py
+++ b/pygotham/manage/events.py
@@ -3,6 +3,7 @@
 import sys
 
 import arrow
+from flask import current_app
 from flask_script import Command, prompt, prompt_bool
 from werkzeug.datastructures import MultiDict
 
@@ -45,7 +46,7 @@ class CreateEvent(Command):
             form.populate_obj(event)
 
             if event.active:
-                now = arrow.utcnow().to('America/New_York').naive
+                now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
                 event.activity_begins = now
 
             db.session.add(event)

--- a/pygotham/news/__init__.py
+++ b/pygotham/news/__init__.py
@@ -1,6 +1,7 @@
 """News package."""
 
 import arrow
+from flask import current_app
 
 from pygotham.core import db
 from pygotham.news.models import Announcement, CallToAction
@@ -10,7 +11,7 @@ __all__ = ('get_active_announcements', 'get_active_call_to_action')
 
 def get_active_announcements():
     """Get the active announcements."""
-    now = arrow.utcnow().to('America/New_York').naive
+    now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
 
     # TODO: Possibly display old announcements if the current event has none.
     return Announcement.query.current.filter(
@@ -21,7 +22,7 @@ def get_active_announcements():
 
 def get_active_call_to_action():
     """Return the active call to action."""
-    now = arrow.utcnow().to('America/New_York').naive
+    now = arrow.utcnow().to(current_app.config['TIME_ZONE']).naive
 
     return CallToAction.query.current.filter(
         CallToAction.active == True,  # NOQA

--- a/pygotham/settings.py
+++ b/pygotham/settings.py
@@ -13,6 +13,7 @@ def bool_(key, default):
 DEBUG = bool_('DEBUG', False)
 SECRET_KEY = env.get('SECRET_KEY', DOES_NOT_EXIST)
 SERVER_NAME = env.get('SERVER_NAME')
+TIME_ZONE = env.get('TIME_ZONE', 'UTC')
 
 GOOGLE_ANALYTICS_PROFILE_ID = env.get('GOOGLE_ANALYTICS_PROFILE_ID')
 


### PR DESCRIPTION
When we had `'America/New_York'` written in one place, it wasn't so bad.
As can be seen from this patch, the time zone is used in a bunch of
different places. Moving it to a setting means we don't have to worry
about typing it wrong.

UTC is being used as the default because it's the least insane time
zone, even though America/New_York will be the most likely time zone to
use.

Closes #277