### PR TITLE
Enable the mobile_show_parent_link navbar option

### DIFF
--- a/pygotham/frontend/templates/layouts/base.html
+++ b/pygotham/frontend/templates/layouts/base.html
@@ -16,7 +16,7 @@
     <script src="{{ url_for('static', filename='bower_components/modernizr/modernizr.js') }}"></script>
   </head>
   <body class="{% block body_class %}{% endblock %}">
-    <nav class="top-bar" data-topbar data-options="mobile_show_parent_link: false">
+    <nav class="top-bar" data-topbar data-options="mobile_show_parent_link: true">
       <ul class="title-area">
         <li class="name">
           <a href="{{ url_for('home.index') }}" title="{{ current_event }} Home">


### PR DESCRIPTION
This setting controls whether or not the parent link is shown in the
navbar dropdown menu mobile view. We previously had this explicitly
disabled. Now that these items may link to actual pages, it should be
enabled.
