### PR TITLE
Add Code of Conduct & Privacy Policy to new events

### DIFF
--- a/pygotham/manage/events.py
+++ b/pygotham/manage/events.py
@@ -1,15 +1,21 @@
 """Event-related management commands."""
 
+import os
 import sys
 
 import arrow
 from flask import current_app
 from flask_script import Command, prompt, prompt_bool
+from slugify import slugify
 from werkzeug.datastructures import MultiDict
 
 from pygotham.core import db
 from pygotham.forms import EventForm
-from pygotham.models import Event
+from pygotham.models import AboutPage, Event
+
+PAGES = {'Code of Conduct', 'Privacy Policy'}
+TEMPLATE_PATH = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), os.path.pardir, 'templates')
 
 
 class CreateEvent(Command):
@@ -28,6 +34,8 @@ class CreateEvent(Command):
         ends = prompt('Event end date')
         proposals_begin = prompt('CFP start date')
         active = prompt_bool('Activate the event')
+
+        add_pages = prompt_bool('Add About pages')
 
         data = MultiDict({
             'name': name,
@@ -50,6 +58,25 @@ class CreateEvent(Command):
                 event.activity_begins = now
 
             db.session.add(event)
+
+            if add_pages:
+                for title in PAGES:
+                    # While the slug will be automatically generated
+                    # when an instance of AboutPage is saved, it's
+                    # needed to open the correct file.
+                    slug = slugify(title)
+
+                    file = os.path.join(TEMPLATE_PATH, slug + '.rst')
+                    with open(file) as f:
+                        AboutPage(
+                            title=title,
+                            slug=slug,
+                            content=f.read(),
+                            navbar_path=['About', title],
+                            event=event,
+                            active=True,
+                        )
+
             db.session.commit()
 
             print('\nEvent created successfully.')

--- a/pygotham/templates/code-of-conduct.rst
+++ b/pygotham/templates/code-of-conduct.rst
@@ -1,0 +1,62 @@
+PyGotham is dedicated to providing a harassment-free conference experience for
+everyone. We do not tolerate harassment of conference participants in any form.
+Conference participants violating these rules may be sanctioned or expelled
+from the conference without a refund at the discretion of the conference
+organizers.
+
+Harassment includes offensive verbal comments related to gender, gender
+identity and expression, sexual orientation, disability, physical appearance,
+body size, race, religion, sexual images in public spaces, deliberate
+intimidation, stalking, following, harassing photography or recording,
+sustained disruption of talks or other events, inappropriate physical contact,
+and unwelcome sexual attention. Participants asked to stop any harassing
+behavior are expected to comply immediately.
+
+Exhibitors in the expo hall, sponsor or vendor booths, or similar activities
+are also subject to the anti-harassment policy. In particular, exhibitors
+should not use sexualized images, activities, or other material. Booth staff
+(including volunteers) should not use sexualized clothing/uniforms/costumes, or
+otherwise create a sexualized environment.
+
+If a participant engages in harassing behavior, the conference organizers may
+take any action they deem appropriate, including warning the offender or
+expulsion from the conference with no refund. If you are being harassed, notice
+that someone else is being harassed, or have any other concerns, please contact
+a member of conference staff immediately. Conference staff can be identified by
+t-shirts/special badges.
+
+PyGotham has an additional rule of no videotaping or photography without prior
+permission. If you wish to photograph, film or record any attendee, including
+speakers, you must first ask for their permission to do so.
+
+Conference staff will be happy to help participants contact hotel/venue
+security or local law enforcement, provide escorts, or otherwise assist those
+experiencing harassment to feel safe for the duration of the conference. We
+value your attendance.
+
+Email address for organizers
+  `organizers@pygotham.org <mailto:organizers@pygotham.org>`_
+
+Phone number for conference organizers
+  929-322-3476
+
+Local law enforcement, emergency
+  911
+
+Local law enforcement, non-emergency
+  311
+
+Local sexual assault hotline
+  800-621-HOPE (4673) or dial 311
+
+Local medical, emergency
+  911
+
+Local medical, non-emergency
+  311
+
+Local taxi company
+  800-609-8731
+
+We expect participants to follow these rules at all conference venues and
+conference-related social events.

--- a/pygotham/templates/privacy-policy.rst
+++ b/pygotham/templates/privacy-policy.rst
@@ -1,0 +1,14 @@
+Information we collect
+  We collect names, email addresses, and passwords. Passwords are encrypted,
+  and we have no way of retrieving them.  If your password is lost, you must
+  reset it through our `forgot password </reset>`_ page.
+
+What we do with this information
+  We take privacy very seriously. We use your contact information to send
+  updates and conference related info to attendees. Information may be shared
+  with third-party vendors conducting business on behalf of the conference. It
+  is not used for any other purpose, nor is it given or sold to any other
+  party, including other attendees or sponsors.
+
+Feel free to contact `organizers@pygotham.org
+<mailto:organizers@pygotham.org>`_ for details involving privacy.


### PR DESCRIPTION
Once upon a time, all of the "static" pages were stored inside the
templates folder of the `frontend` application. This had the advantage
of being able to see the change history of documents such as the Code of
Conduct and Privacy Policy. This disadvantage was that applications with
multiple events would have the same copy for the pages.

0418bda introduced the `AboutPage` model. This model was used to move
many of the "static" pages out of the templates and into the database.
This not only allowed events to have their own version of page, but
events could have their own set of pages. It also introduced the
advantage of being able to update the copy on a page without deploying
code.

The disadvantage here is that it becomes harder for people to track
changes we make to the aforementioned documents. Given their nature, the
more transparent we can be able them, the better.

This changeset not only gives us the ability to begin tracking the
changes we make to them, but it also allows us to prepopulate them when
adding new events through the `create_event` management command.

---

While it isn't required that we make all changes to the Code of Conduct
and Privacy Policy through the new reStructuredText documents being
added here, it should be strongly encouraged that we do so.

If we follow this policy, the overhead to make changes to the pages
actually goes up, but I believe the ends justify the means.