### PR TITLE
Add talk reviewer permission

### DIFF
--- a/migrations/versions/90f1af83d9b6_add_reviewer_role.py
+++ b/migrations/versions/90f1af83d9b6_add_reviewer_role.py
@@ -1,0 +1,27 @@
+"""Add reviewer role
+
+Revision ID: 90f1af83d9b6
+Revises: 5d619660cfa7
+Create Date: 2016-05-17 02:16:30.097950
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '90f1af83d9b6'
+down_revision = '5d619660cfa7'
+
+from alembic import op
+
+
+def upgrade():
+    """Add reviewer role."""
+    op.execute("INSERT INTO roles (name) VALUES ('reviewer');")
+
+
+def downgrade():
+    """Remove reviewer role and dependencies."""
+    op.execute(
+        "DELETE FROM roles_users WHERE role_id in ("
+        "SELECT id FROM roles WHERE name='reviewer');"
+    )
+    op.execute("DELETE FROM roles WHERE name='reviewer';")

--- a/pygotham/admin/talks.py
+++ b/pygotham/admin/talks.py
@@ -65,6 +65,7 @@ TalkReviewModelView = model_view(
     models.Talk,
     'Review',
     CATEGORY,
+    acceptable_roles=('reviewer',),
     can_create=False,
     can_delete=False,
     column_default_sort='id',

--- a/pygotham/admin/utils.py
+++ b/pygotham/admin/utils.py
@@ -12,8 +12,13 @@ __all__ = ('menu_link', 'model_view')
 class AdminModelView(ModelView):
     """Base class for all protected admin model-based views."""
 
+    acceptable_roles = []
+
     def is_accessible(self):
-        return current_user.has_role('admin')
+        """Return ``True`` if any acceptable role is found."""
+        acceptable_roles = set(self.acceptable_roles)
+        acceptable_roles.add('admin')
+        return any(current_user.has_role(role) for role in acceptable_roles)
 
 
 class AuthenticatedMenuLink(MenuLink):


### PR DESCRIPTION
The talk review committee consists of more than just super-admins, so
the review pages should be accessible to them. This commit enables this
participation in three steps:

1. Add a reviewer role.
2. Modify the talk review pages to allow access to users with the
   reviewer role.
3. Modify the `AdminModelView.is_accessible` function to check for any
   desired roles and the `admin` super-role.