### PR TITLE
Changes to Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Docker's files
+Dockerfile
+.dockerignore
+
+# Documentation
+*.rst
+docs/
+LICENSE
+
+# Testing
+.travis.yml
+dev-requirements.txt
+requirements.in
+setup.cfg
+tox.ini

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,9 @@
 Dockerfile
 .dockerignore
 
+# Data used by other containers
+data/
+
 # Documentation
 *.rst
 docs/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ instance/settings.cfg
 
 .vagrant
 
+# Stuff used by Docker
+data/
+
 # These should go in a global .gitignore, but not everyone uses one.
 *~
 *.sw?

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM python:3.5.1
+FROM python:3.5.1-alpine
 
 WORKDIR /code
 EXPOSE 9000
 
 # Add Tini
-ENV TINI_VERSION v0.9.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+RUN apk --update add \
+    --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+    tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
+RUN apk --update add \
+    gcc \
+    linux-headers \
+    musl \
+    musl-dev \
+    postgresql-dev
 RUN python -m pip install uwsgi
 
 COPY requirements.txt /code/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ db:
   image: postgres
   ports:
     - "5432:5432"
+  volumes:
+    - ./data/postgresql:/var/lib/postgresql/data
   environment:
     - POSTGRES_USER=pygotham
     - POSTGRES_PASSWORD=pygotham


### PR DESCRIPTION
A few changes are being made to our Docker setup. To start, the base
image is being changed to use Alpine. It's a much smaller image than the
default Python image. This will result in a smaller memory footprint,
plus faster build times.

Next, a .dockerignore file is being added to help further reduce the
image size. There isn't a whole lot for us to ignore (yet), but this
could potentially grow over time.

Lastly, an external volume is being added to the database image to allow
anyone developing with Docker Compose to keep their data after they've
deleted the container.