### PR TITLE
Don't let Docker ignore the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 # Docker's files
-Dockerfile
 .dockerignore
 
 # Data used by other containers


### PR DESCRIPTION
Even though Docker can still build an image when it doesn't have the
Dockerfile, quay.io doesn't support it[1]. The Dockerfile is being
removed from .dockerignore to fix our broken builds.

[1] https://docs.quay.io/issues/cannot-locate-dockerfile.html