### PR TITLE
Fix schedule rendering

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,8 @@ Flask-WTF
 psycopg2
 python-slugify
 raven
-SQLAlchemy-Utils
+SQLAlchemy<1
+SQLAlchemy-Utils==0.30.0
 WTForms
-WTForms-Alchemy
-WTForms-Components
+WTForms-Alchemy==0.13.1
+WTForms-Components==0.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,11 +41,11 @@ pytz==2015.7              # via flask-restful
 raven==5.10.2
 six==1.10.0               # via bleach, flask-restful, html5lib, python-dateutil, sqlalchemy-utils, validators, wtforms-alchemy, wtforms-components
 sortedcontainers==1.4.4   # via flask-copilot
-SQLAlchemy-Utils==0.31.6  # via wtforms-alchemy
-SQLAlchemy==1.0.11        # via alembic, flask-sqlalchemy, sqlalchemy-utils, wtforms-alchemy
+SQLAlchemy-Utils==0.30.0  # via wtforms-alchemy, wtforms-components
+SQLAlchemy==0.9.10        # via alembic, flask-sqlalchemy, sqlalchemy-utils, wtforms-alchemy, wtforms-components
 Unidecode==0.4.19         # via python-slugify
 validators==0.10          # via wtforms-components
 Werkzeug==0.11.3          # via flask, flask-wtf
-WTForms-Alchemy==0.15.0
-WTForms-Components==0.10.0  # via wtforms-alchemy
+WTForms-Alchemy==0.13.1
+WTForms-Components==0.9.7  # via wtforms-alchemy
 WTForms==2.1              # via flask-admin, flask-wtf, wtforms-alchemy, wtforms-components


### PR DESCRIPTION
SQLAlchemy 1.0 introduced a change that wraps query results containing
fields from multiple tables in a "result" collection. This causes
problems for us when we try to assign a rowspan to each slot.
Downgrading to a version of SQLAlchemy prior to 1.0 fixes this.

We should look into a solution that will allow us to upgrade again, but
since we want to publish the schedule soon, this will have to do for
now.