### PR TITLE
Hide navbar children when appropriate

### DIFF
--- a/pygotham/frontend/templates/layouts/base.html
+++ b/pygotham/frontend/templates/layouts/base.html
@@ -31,11 +31,11 @@
       <section class="top-bar-section">
         <ul class="right">
           {% for entry in navbar %}
-          <li class="{{ entry.name }} {% if entry.children %}has-dropdown{% endif %}">
+          <li class="{{ entry.name }} {% if entry.visible_children|list %}has-dropdown{% endif %}">
               <a href="{{ entry.url() }}">{{ entry.name }}</a>
-              {% if entry.children %}
+              {% if entry.visible_children|list %}
               <ul class="dropdown">
-                {% for child in entry.children %}
+                {% for child in entry.visible_children %}
                 <li><a href="{{ child.url() }}">{{ child.name }}</a></li>
                 {% endfor %}
               </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ contextlib2==0.5.1        # via raven
 decorator==4.0.6          # via validators
 docutils==0.12
 Flask-Admin==1.4.0
-flask-copilot==0.1.0
+flask-copilot==0.2.0
 Flask-Login==0.2.11       # via flask-security
 Flask-Mail==0.9.1         # via flask-security
 Flask-Migrate==1.7.0


### PR DESCRIPTION
Due to how Flask-Copilot used to handle navbar entry children, it was
not easy to hide invisible children. Update Flask-Copilot and render the
navbar properly.