### PR TITLE
Add subdomain support to the API

### DIFF
--- a/pygotham/api/events.py
+++ b/pygotham/api/events.py
@@ -8,7 +8,8 @@ from pygotham.events.models import Event
 from .fields import event_fields
 
 
-blueprint = Blueprint('events', __name__, url_prefix='/events')
+blueprint = Blueprint(
+    'events', __name__, subdomain='<event_slug>', url_prefix='/events')
 api = Api(blueprint)
 
 

--- a/pygotham/api/schedule.py
+++ b/pygotham/api/schedule.py
@@ -9,7 +9,11 @@ from pygotham.talks.models import Talk
 from .fields import talk_fields
 
 blueprint = Blueprint(
-    'schedule', __name__, url_prefix='/events/<int:event_id>/schedule')
+    'schedule',
+    __name__,
+    subdomain='<event_slug>',
+    url_prefix='/events/<int:event_id>/schedule',
+)
 api = Api(blueprint)
 
 


### PR DESCRIPTION
Because of the `SERVER_NAME`, the API currently does not work. As a
short term hot fix, this change gets the API back into a working state.
In the long term, we should either use the event identified by the
subdomain in all API requests or split the API application out into a
separately deployed application (e.g. `https://api.pygotham.org/`).