### PR TITLE
Add scholarship information to the registration page

### DIFF
--- a/pygotham/frontend/templates/registration/information.html
+++ b/pygotham/frontend/templates/registration/information.html
@@ -49,6 +49,17 @@
         </tbody>
       </table>
 
+      <h2>Scholarships</h2>
+
+      <p>We aim for PyGotham to be open to all to attend, and we strive to make
+        the conference as accessible as possible. If you aren't able to obtain a
+        ticket for financial or other reasons, please fill out the application
+        at <a href="https://goo.gl/forms/uEQ55S18V5">
+        https://goo.gl/forms/uEQ55S18V5</a>, and we'll arrange for a reduced
+        amount or a free scholarship ticket to ensure that you can attend. Feel
+        free to ping us at <a href="mailto:scholarships@pygotham.org">
+        scholarships@pygotham.org</a> if you have any questions.</p>
+
       <h2>What's Included?</h2>
 
       <p>Along with your conference registration, attendees will receive


### PR DESCRIPTION
This information already exists on our FAQ page, but it's also
appropriate here.

Note: the application form link will need to be updated for new events.
Ideally, this form becomes part of the site instead of linking
elsewhere.