### PR TITLE
Pin (sort of) the version of flake8-docstrings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv:pep8]
 basepython = python3.5
 deps =
-    flake8-docstrings
+    flake8-docstrings<1
     pep8-naming
 commands =
     flake8 pygotham


### PR DESCRIPTION
`pep257` was renamed to `pydocstyle`. Part of the initial release under
the new name is a change that treats classes nested inside other classes
as public as long as they aren't named with a leading underscore.
`flake8-docstrings` 1.0 is the first release to use the new name.

This causes linting errors with this codebase because `WTForms-Alchemy`
and `Flask-RESTful` both use a nested class named `Meta` to describe
their outer class. Until we figure out how we want to handle this going
forward, the version of `flake8-docstrings` is being restricted to
anything prior to 1.0 so that other changes can be made and merged after
their builds pass.