### PR TITLE
Bring code up to PEP 8 standards

### DIFF
--- a/pygotham/schedule/models.py
+++ b/pygotham/schedule/models.py
@@ -53,6 +53,7 @@ def pairwise(iterable):
     next(b, None)
     return zip(a, b)
 
+
 rooms_slots = db.Table(
     'rooms_slots',
     db.Column('slot_id', db.Integer, db.ForeignKey('slots.id')),


### PR DESCRIPTION
An issue was opened with pycodestyle (PyCQA/pycodestyle#400) to address
a discrepancy with PEP 8. This blank line addresses that.