### PR TITLE
Add format hints to the create_event command

### DIFF
--- a/pygotham/manage/events.py
+++ b/pygotham/manage/events.py
@@ -24,9 +24,9 @@ class CreateEvent(Command):
         # Get the information.
         name = prompt('Name')
         slug = prompt('Slug (optional)')
-        begins = prompt('Event start date')
-        ends = prompt('Event end date')
-        proposals_begin = prompt('CFP start date')
+        begins = prompt('Event start date (YYYY-MM-DD)')
+        ends = prompt('Event end date (YYYY-MM-DD)')
+        proposals_begin = prompt('CFP start date (YYYY-MM-DD HH:MM:SS)')
         active = prompt_bool('Activate the event')
 
         data = MultiDict({


### PR DESCRIPTION
Whenever I use the `create_event` command (typically this only happens
when I set up a new development instance of PyGotham) I forget that the
CFP start date field requires a datetime. This causes the command fails
to create the event, requiring me to run the command again and enter all
of the information all over again. By providing format hints as part of
the prompt, people won't need to know the underlying data model to know
how to enter the values for dates and datetimes.

Signed-off-by: Andy Dirnberger <andy@dirnberger.me>