### PR TITLE
Install correct major version of jQuery

### DIFF
--- a/pygotham/frontend/static/bower.json
+++ b/pygotham/frontend/static/bower.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "private": "true",
   "dependencies": {
-    "foundation": "zurb/bower-foundation"
+    "foundation": "zurb/bower-foundation#15d98294916c50ce8e6838bc035f4f136d4dc704"
   }
 }


### PR DESCRIPTION
Foundation's bower-specific release contains a version requirement for
jQuery that specifies being greater than or equal to 2.1. jQuery 3.0
contains a change that is incompatible with Foundation. There is an
upstream commit that fixes the version requirement that pins jQuery to
2.1.x.

The sha of the commit is being specified in the bower file to force it
to install a version of Foundation that will install the correct version
of jQuery.

(This could also be fixed by upgrading the version of Foundation, now
called `foundation-sites`, but that's potentially a much larger change.)

Signed-off-by: Andy Dirnberger <andy@dirnberger.me>